### PR TITLE
Changed the way in which merkle tree endpoints are processed

### DIFF
--- a/rest/src/db/CatapultDb.js
+++ b/rest/src/db/CatapultDb.js
@@ -192,13 +192,12 @@ class CatapultDb {
 		).then(this.sanitizer.deleteId);
 	}
 
-	blockWithStatementMerkleTreeAtHeight(height) {
-		return this.queryDocument('blocks', { 'block.height': convertToLong(height) }, { 'meta.transactionMerkleTree': 0 })
-			.then(this.sanitizer.deleteId);
-	}
-
-	blockWithTransactionMerkleTreeAtHeight(height) {
-		return this.queryDocument('blocks', { 'block.height': convertToLong(height) }, { 'meta.statementMerkleTree': 0 })
+	blockWithMerkleTreeAtHeight(height, merkleTreeName) {
+		const blockMerkleTreeNames = ['transactionMerkleTree', 'statementMerkleTree'];
+		const excludedMerkleTrees = {};
+		blockMerkleTreeNames.filter(merkleTree => merkleTree !== merkleTreeName)
+			.forEach(merkleTree => { excludedMerkleTrees[`meta.${merkleTree}`] = 0; });
+		return this.queryDocument('blocks', { 'block.height': convertToLong(height) }, excludedMerkleTrees)
 			.then(this.sanitizer.deleteId);
 	}
 

--- a/rest/src/plugins/routes/receiptsRoutes.js
+++ b/rest/src/plugins/routes/receiptsRoutes.js
@@ -65,7 +65,7 @@ module.exports = {
 
 		server.get(
 			'/block/:height/receipt/:hash/merkle',
-			routeUtils.blockRouteMerkleProcessor(db, db.blockWithStatementMerkleTreeAtHeight, 'numStatements', 'statementMerkleTree')
+			routeUtils.blockRouteMerkleProcessor(db, 'numStatements', 'statementMerkleTree')
 		);
 	}
 };

--- a/rest/src/routes/blockRoutes.js
+++ b/rest/src/routes/blockRoutes.js
@@ -46,7 +46,7 @@ module.exports = {
 
 		server.get(
 			'/block/:height/transaction/:hash/merkle',
-			routeUtils.blockRouteMerkleProcessor(db, db.blockWithTransactionMerkleTreeAtHeight, 'numTransactions', 'transactionMerkleTree')
+			routeUtils.blockRouteMerkleProcessor(db, 'numTransactions', 'transactionMerkleTree')
 		);
 
 		server.get('/block/:height/transactions', (req, res, next) => {

--- a/rest/src/routes/routeUtils.js
+++ b/rest/src/routes/routeUtils.js
@@ -273,16 +273,15 @@ const routeUtils = {
 	/**
 	 * Returns function for processing merkle tree path requests.
 	 * @param {module:db/CatapultDb} db The catapult database.
-	 * @param {function} blockAtHeightDbFunction Function that queries db for block at height.
 	 * @param {string} blockMetaCountField Field name for block meta count.
 	 * @param {string} blockMetaTreeField Field name for block meta merkle tree.
 	 * @returns {Function} The restify response function to process merkle path requests.
 	 */
-	blockRouteMerkleProcessor: (db, blockAtHeightDbFunction, blockMetaCountField, blockMetaTreeField) => (req, res, next) => {
+	blockRouteMerkleProcessor: (db, blockMetaCountField, blockMetaTreeField) => (req, res, next) => {
 		const height = routeUtils.parseArgument(req.params, 'height', 'uint');
 		const hash = routeUtils.parseArgument(req.params, 'hash', 'hash256');
 
-		return dbFacade.runHeightDependentOperation(db, height, () => blockAtHeightDbFunction(height))
+		return dbFacade.runHeightDependentOperation(db, height, () => db.blockWithMerkleTreeAtHeight(height, blockMetaTreeField))
 			.then(result => {
 				if (!result.isRequestValid) {
 					res.send(errors.createNotFoundError(height));

--- a/rest/test/db/CatapultDb_spec.js
+++ b/rest/test/db/CatapultDb_spec.js
@@ -185,7 +185,7 @@ describe('catapult db', () => {
 			// Assert:
 			runDbTest(
 				{ block: test.db.createDbBlock(Default_Height) },
-				db => db.blockWithStatementMerkleTreeAtHeight(Long.fromNumber(Default_Height + 1)),
+				db => db.blockWithMerkleTreeAtHeight(Long.fromNumber(Default_Height + 1), 'statementMerkleTree'),
 				block => expect(block).to.equal(undefined)
 			));
 
@@ -198,7 +198,7 @@ describe('catapult db', () => {
 			// Assert:
 			return runDbTest(
 				{ block: seedBlock },
-				db => db.blockWithStatementMerkleTreeAtHeight(height),
+				db => db.blockWithMerkleTreeAtHeight(height, 'statementMerkleTree'),
 				block => expect(block).to.deep.equal(stripBlockFields(seedBlock, ['transactionMerkleTree']))
 			);
 		};
@@ -216,7 +216,7 @@ describe('catapult db', () => {
 			// Assert:
 			return runDbTest(
 				{ block: seedBlock, transactions: blockTransactions },
-				db => db.blockWithStatementMerkleTreeAtHeight(Long.fromNumber(Default_Height)),
+				db => db.blockWithMerkleTreeAtHeight(Long.fromNumber(Default_Height), 'statementMerkleTree'),
 				block => expect(block).to.deep.equal(stripBlockFields(seedBlock, ['transactionMerkleTree']))
 			);
 		});
@@ -227,7 +227,7 @@ describe('catapult db', () => {
 			// Assert:
 			runDbTest(
 				{ block: test.db.createDbBlock(Default_Height) },
-				db => db.blockWithTransactionMerkleTreeAtHeight(Long.fromNumber(Default_Height + 1)),
+				db => db.blockWithMerkleTreeAtHeight(Long.fromNumber(Default_Height + 1), 'transactionMerkleTree'),
 				block => expect(block).to.equal(undefined)
 			));
 
@@ -240,7 +240,7 @@ describe('catapult db', () => {
 			// Assert:
 			return runDbTest(
 				{ block: seedBlock },
-				db => db.blockWithTransactionMerkleTreeAtHeight(height),
+				db => db.blockWithMerkleTreeAtHeight(height, 'transactionMerkleTree'),
 				block => expect(block).to.deep.equal(stripBlockFields(seedBlock, ['statementMerkleTree']))
 			);
 		};
@@ -258,7 +258,7 @@ describe('catapult db', () => {
 			// Assert:
 			return runDbTest(
 				{ block: seedBlock, transactions: blockTransactions },
-				db => db.blockWithTransactionMerkleTreeAtHeight(Long.fromNumber(Default_Height)),
+				db => db.blockWithMerkleTreeAtHeight(Long.fromNumber(Default_Height), 'transactionMerkleTree'),
 				block => expect(block).to.deep.equal(stripBlockFields(seedBlock, ['statementMerkleTree']))
 			);
 		});

--- a/rest/test/plugins/routes/receiptsRoutes_spec.js
+++ b/rest/test/plugins/routes/receiptsRoutes_spec.js
@@ -137,8 +137,8 @@ describe('receipts routes', () => {
 
 			// Assert:
 			expect(blockRouteMerkleProcessorSpy.calledOnce).to.equal(true);
-			expect(blockRouteMerkleProcessorSpy.firstCall.args[2]).to.equal('numStatements');
-			expect(blockRouteMerkleProcessorSpy.firstCall.args[3]).to.equal('statementMerkleTree');
+			expect(blockRouteMerkleProcessorSpy.firstCall.args[1]).to.equal('numStatements');
+			expect(blockRouteMerkleProcessorSpy.firstCall.args[2]).to.equal('statementMerkleTree');
 			blockRouteMerkleProcessorSpy.restore();
 		});
 	});

--- a/rest/test/routes/blockRoutes_spec.js
+++ b/rest/test/routes/blockRoutes_spec.js
@@ -143,8 +143,8 @@ describe('block routes', () => {
 
 			// Assert:
 			expect(blockRouteMerkleProcessorSpy.calledOnce).to.equal(true);
-			expect(blockRouteMerkleProcessorSpy.firstCall.args[2]).to.equal('numTransactions');
-			expect(blockRouteMerkleProcessorSpy.firstCall.args[3]).to.equal('transactionMerkleTree');
+			expect(blockRouteMerkleProcessorSpy.firstCall.args[1]).to.equal('numTransactions');
+			expect(blockRouteMerkleProcessorSpy.firstCall.args[2]).to.equal('transactionMerkleTree');
 			blockRouteMerkleProcessorSpy.restore();
 		});
 	});

--- a/rest/test/routes/routeUtils_spec.js
+++ b/rest/test/routes/routeUtils_spec.js
@@ -477,15 +477,17 @@ describe('route utils', () => {
 		const blockMetaCountField = 'blockMetaCountField';
 		const blockMetaTreeField = 'blockMetaTreeField';
 
-		const db = { chainInfo: () => Promise.resolve({ height: highestHeight }) };
 		const blockInfoMockData = { meta: {} };
 		blockInfoMockData.meta[blockMetaCountField] = 4;
 		blockInfoMockData.meta[blockMetaTreeField] = merkleTree;
-		const blockAtHeightDbFunction = () => Promise.resolve(blockInfoMockData);
+
+		const db = {
+			chainInfo: () => Promise.resolve({ height: highestHeight }),
+			blockWithMerkleTreeAtHeight: () => Promise.resolve(blockInfoMockData)
+		};
 
 		const processorFunction = routeUtils.blockRouteMerkleProcessor(
 			db,
-			blockAtHeightDbFunction,
 			blockMetaCountField,
 			blockMetaTreeField
 		);


### PR DESCRIPTION
Fixes #14, there was a problem with lost context (_this._) when passing the specific merkle db function, made the way in which this is managed more generic