### PR TITLE
Refactor and fix receipts

### DIFF
--- a/rest/src/plugins/db/ReceiptsDb.js
+++ b/rest/src/plugins/db/ReceiptsDb.js
@@ -30,30 +30,13 @@ class ReceiptsDb {
 	}
 
 	/**
-	* Retrieves all address resolution statements in a given block.
+	* Retrieves all the statements in a given collection and block.
 	* @param {module:catapult.utils/uint64~uint64} height The given block height.
-	* @returns {Promise.<array>} Address resolution statements in a block.
+	* @param {string} statementsCollection The statements collection.
+	* @returns {Promise.<array>} Statements from a collection in a block.
 	*/
-	addressResolutionStatementsAtHeight(height) {
-		return this.catapultDb.queryDocuments('addressResolutionStatements', { height: convertToLong(height) });
-	}
-
-	/**
-	* Retrieves all mosaic resolution statements in a given block.
-	* @param {module:catapult.utils/uint64~uint64} height The given block height.
-	* @returns {Promise.<array>} Mosaic resolution statements in a block.
-	*/
-	mosaicResolutionStatementsAtHeight(height) {
-		return this.catapultDb.queryDocuments('mosaicResolutionStatements', { height: convertToLong(height) });
-	}
-
-	/**
-	* Retrieves all transaction statements in a given block.
-	* @param {module:catapult.utils/uint64~uint64} height The given block height.
-	* @returns {Promise.<array>} Transaction statements in a block.
-	*/
-	transactionStatementsAtHeight(height) {
-		return this.catapultDb.queryDocuments('transactionStatements', { height: convertToLong(height) });
+	statementsAtHeight(height, statementsCollection) {
+		return this.catapultDb.queryDocuments(statementsCollection, { height: convertToLong(height) });
 	}
 }
 

--- a/rest/test/plugins/db/ReceiptsDb_spec.js
+++ b/rest/test/plugins/db/ReceiptsDb_spec.js
@@ -36,7 +36,7 @@ describe('receipts db', () => {
 			// Assert:
 			test.addressResolutionStatementDb.runDbTest(
 				[addressResolutionsStatement1, addressResolutionsStatement2, addressResolutionsStatement3],
-				db => db.addressResolutionStatementsAtHeight(Long.fromNumber(knownHeight + 10)),
+				db => db.statementsAtHeight(Long.fromNumber(knownHeight + 10), 'addressResolutionStatements'),
 				entities => { expect(entities).to.deep.equal([]); }
 			));
 
@@ -44,7 +44,7 @@ describe('receipts db', () => {
 			// Assert:
 			test.addressResolutionStatementDb.runDbTest(
 				[addressResolutionsStatement1, addressResolutionsStatement2, addressResolutionsStatement3],
-				db => db.addressResolutionStatementsAtHeight(Long.fromNumber(knownHeight)),
+				db => db.statementsAtHeight(Long.fromNumber(knownHeight), 'addressResolutionStatements'),
 				entities => { expect(entities).to.deep.equal([addressResolutionsStatement1, addressResolutionsStatement2]); }
 			));
 	});
@@ -60,7 +60,7 @@ describe('receipts db', () => {
 			// Assert:
 			test.mosaicResolutionStatementDb.runDbTest(
 				[mosaicResolutionsStatement1, mosaicResolutionsStatement2, mosaicResolutionsStatement3],
-				db => db.mosaicResolutionStatementsAtHeight(Long.fromNumber(knownHeight + 10)),
+				db => db.statementsAtHeight(Long.fromNumber(knownHeight + 10), 'mosaicResolutionStatements'),
 				entities => { expect(entities).to.deep.equal([]); }
 			));
 
@@ -68,7 +68,7 @@ describe('receipts db', () => {
 			// Assert:
 			test.mosaicResolutionStatementDb.runDbTest(
 				[mosaicResolutionsStatement1, mosaicResolutionsStatement2, mosaicResolutionsStatement3],
-				db => db.mosaicResolutionStatementsAtHeight(Long.fromNumber(knownHeight)),
+				db => db.statementsAtHeight(Long.fromNumber(knownHeight), 'mosaicResolutionStatements'),
 				entities => { expect(entities).to.deep.equal([mosaicResolutionsStatement1, mosaicResolutionsStatement2]); }
 			));
 	});
@@ -84,7 +84,7 @@ describe('receipts db', () => {
 			// Assert:
 			test.transactionStatementDb.runDbTest(
 				[transactionStatement1, transactionStatement2, transactionStatement3],
-				db => db.transactionStatementsAtHeight(Long.fromNumber(knownHeight + 10)),
+				db => db.statementsAtHeight(Long.fromNumber(knownHeight + 10), 'transactionStatements'),
 				entities => { expect(entities).to.deep.equal([]); }
 			));
 
@@ -92,7 +92,7 @@ describe('receipts db', () => {
 			// Assert:
 			test.transactionStatementDb.runDbTest(
 				[transactionStatement1, transactionStatement2, transactionStatement3],
-				db => db.transactionStatementsAtHeight(Long.fromNumber(knownHeight)),
+				db => db.statementsAtHeight(Long.fromNumber(knownHeight), 'transactionStatements'),
 				entities => { expect(entities).to.deep.equal([transactionStatement1, transactionStatement2]); }
 			));
 	});

--- a/rest/test/plugins/routes/receiptsRoutes_spec.js
+++ b/rest/test/plugins/routes/receiptsRoutes_spec.js
@@ -49,7 +49,7 @@ describe('receipts routes', () => {
 
 		receiptsRoutes.register(server, {
 			catapultDb: {
-				chainInfo: () => Promise.resolve({ height: highestHeight }),
+				chainInfo: () => Promise.resolve({ height: highestHeight })
 			},
 			statementsAtHeight: statementsFake
 		});


### PR DESCRIPTION
Helps fixing #14 , based on the latest merkle improvements commit and fixes potential context issues with the receipts plugin, and solves the limitation of accessing catapultDb from a plugin which resulted in the error `db.chainInfo not a function`