### PR TITLE
websocket configuration was not exposed for services

### DIFF
--- a/rest/src/index.js
+++ b/rest/src/index.js
@@ -107,7 +107,8 @@ const registerRoutes = (server, db, services) => {
 				max: services.config.db.pageSizeMax,
 				step: services.config.db.pageSizeStep
 			},
-			apiNode: services.config.apiNode
+			apiNode: services.config.apiNode,
+			websocket: services.config.websocket
 		},
 		connections: services.connectionService
 	};


### PR DESCRIPTION
MessageChannelBuilder is created through routeSystem which only has access to servicesView configuration.

this bug was introduced in alpaca as a result of two separate changes: 
 1. that was adding servicesView configuration
 2. that turned routeSystem into a plugin + adding MessageChannelBuilder in process