### PR TITLE
Fix path to follow project require path convention

### DIFF
--- a/rest/src/db/CatapultDb.js
+++ b/rest/src/db/CatapultDb.js
@@ -23,7 +23,7 @@
 const catapult = require('catapult-sdk');
 const connector = require('./connector');
 const MongoDb = require('mongodb');
-const { convertToLong } = require('../../src/db/dbUtils');
+const { convertToLong } = require('./dbUtils');
 
 const { address, EntityType } = catapult.model;
 const { ObjectId } = MongoDb;


### PR DESCRIPTION
The require path should follow the convention set in the project. Eg. `const connector = require('./connector');` on line 24. 