### PR TITLE
Changed restriction type mask to 0x3F

### DIFF
--- a/catapult-sdk/src/plugins/accountRestrictions.js
+++ b/catapult-sdk/src/plugins/accountRestrictions.js
@@ -111,7 +111,7 @@ const accountRestrictionsPlugin = {
 			});
 		});
 
-		// accountrestriction fallback
+		// account restriction fallback
 		builder.addSchema('accountRestriction.fallback', {});
 
 		// aggregated account restrictions schemas

--- a/catapult-sdk/src/plugins/accountRestrictions.js
+++ b/catapult-sdk/src/plugins/accountRestrictions.js
@@ -110,7 +110,7 @@ const accountRestrictionsPlugin = {
 				values: { type: ModelType.array, schemaName: restrictionTypeDescriptor.valueType }
 			});
 		});
-		
+
 		// accountrestriction fallback
 		builder.addSchema('accountRestriction.fallback', {});
 

--- a/catapult-sdk/src/plugins/accountRestrictions.js
+++ b/catapult-sdk/src/plugins/accountRestrictions.js
@@ -110,6 +110,9 @@ const accountRestrictionsPlugin = {
 				values: { type: ModelType.array, schemaName: restrictionTypeDescriptor.valueType }
 			});
 		});
+		
+		// accountrestriction fallback
+		builder.addSchema('accountRestriction.fallback', {});
 
 		// aggregated account restrictions schemas
 		builder.addSchema('accountRestrictions', {
@@ -121,10 +124,10 @@ const accountRestrictionsPlugin = {
 				type: ModelType.array,
 				schemaName: entity => {
 					for (let i = 0; i < accountRestrictionTypeDescriptors.length; i++) {
-						if ((entity.restrictionType & 0x7F) === accountRestrictionTypeDescriptors[i].flag)
+						if ((entity.restrictionType & 0x3F) === accountRestrictionTypeDescriptors[i].flag)
 							return `accountRestriction.${accountRestrictionTypeDescriptors[i].schemaPrefix}AccountRestriction`;
 					}
-					return undefined;
+					return 'accountRestriction.fallback';
 				}
 			}
 		});

--- a/catapult-sdk/test/plugins/accountRestrictions_spec.js
+++ b/catapult-sdk/test/plugins/accountRestrictions_spec.js
@@ -61,13 +61,14 @@ describe('account restrictions plugin', () => {
 			const modelSchema = builder.build();
 
 			// Assert:
-			expect(Object.keys(modelSchema).length).to.equal(numDefaultKeys + 11);
+			expect(Object.keys(modelSchema).length).to.equal(numDefaultKeys + 12);
 			expect(modelSchema).to.contain.all.keys([
 				'accountRestrictionAddress',
 				'accountRestrictionMosaic',
 				'accountRestrictionOperation',
 				'accountRestrictions',
-				'accountRestriction.restrictions'
+				'accountRestriction.restrictions',
+				'accountRestriction.fallback'
 			].concat(modificationTypeSchemas).concat(accountRestrictionSchemas));
 
 			// - accountRestrictionAddress
@@ -124,6 +125,8 @@ describe('account restrictions plugin', () => {
 					.to.equal('accountRestriction.operationAccountRestriction');
 				expect(accountRestrictionSchema({ restrictionType: AccountRestrictionType.operationBlock }))
 					.to.equal('accountRestriction.operationAccountRestriction');
+				expect(accountRestrictionSchema({ restrictionType: 99 }))
+					.to.equal('accountRestriction.fallback');
 			});
 		});
 	});


### PR DESCRIPTION
Fixes #67 

The **0x7F** mask used to identify the restriction types should be **0x3F**. Otherwise values like 0xC4, outgoing Operation block, aren't treated properly.