### PR TITLE
Added the uint64String formatter

### DIFF
--- a/catapult-sdk/src/model/ModelType.js
+++ b/catapult-sdk/src/model/ModelType.js
@@ -43,10 +43,13 @@ const ModelType = {
 	uint16: SchemaType.max + 5,
 
 	/** Schema property type indicating a uint64 value. */
-	uint64: SchemaType.max + 6
+	uint64: SchemaType.max + 6,
+
+	/** Schema property type indicating a uint64 value as string. */
+	uint64String: SchemaType.max + 7
 };
 
 Object.assign(ModelType, SchemaType);
-ModelType.max = ModelType.uint64;
+ModelType.max = ModelType.uint64String;
 
 module.exports = ModelType;

--- a/catapult-sdk/src/utils/uint64.js
+++ b/catapult-sdk/src/utils/uint64.js
@@ -116,7 +116,30 @@ const uint64Module = {
 	 * @param {module:utils/uint64~uint64} uint64 A uint64 value.
 	 * @returns {boolean} true if the value is zero.
 	 */
-	isZero: uint64 => 0 === uint64[0] && 0 === uint64[1]
+	isZero: uint64 => 0 === uint64[0] && 0 === uint64[1],
+
+	/**
+	 * Converts a uint64 into a numeric string.
+	 * @param {module:utils/uint64~uint64} uint64 A uint64 value.
+	 * @returns {string} A numeric string representation of the input.
+	 */
+	toString: uint64 => {
+		const hexUint64 = uint64Module.toHex(uint64);
+		const digits = [0];
+		for (let i = 0; i < hexUint64.length; i += 1) {
+			let carry = parseInt(hexUint64.charAt(i), 16);
+			for (let j = 0; j < digits.length; j += 1) {
+				digits[j] = (digits[j] * 16) + carry;
+				carry = digits[j] / 10 | 0;
+				digits[j] %= 10;
+			}
+			while (0 < carry) {
+				digits.push(carry % 10);
+				carry = carry / 10 | 0;
+			}
+		}
+		return digits.reverse().join('');
+	}
 };
 
 module.exports = uint64Module;

--- a/catapult-sdk/test/model/ModelType_spec.js
+++ b/catapult-sdk/test/model/ModelType_spec.js
@@ -35,7 +35,8 @@ describe('model type enumeration', () => {
 			string: 7,
 			uint16: 8,
 			uint64: 9,
-			max: 9
+			uint64String: 10,
+			max: 10
 		});
 	});
 });

--- a/catapult-sdk/test/utils/uint64_spec.js
+++ b/catapult-sdk/test/utils/uint64_spec.js
@@ -230,4 +230,13 @@ describe('uint64', () => {
 			});
 		});
 	});
+
+	describe('toString', () => {
+		it('parses uint64 values correctly', () => {
+			expect(uint64.toString([0, 0])).to.equal('0');	// min value
+			expect(uint64.toString([4294967295, 4294967295])).to.equal('18446744073709551615');	// max value
+			expect(uint64.toString([65436453, 45])).to.equal('193338964773');
+			expect(uint64.toString([3127188303, 2974383967])).to.equal('12774881867138931535');
+		});
+	});
 });

--- a/rest/src/db/dbFormattingRules.js
+++ b/rest/src/db/dbFormattingRules.js
@@ -25,6 +25,8 @@ const { Binary } = require('mongodb');
 const { ModelType, status } = catapult.model;
 const { convert, uint64 } = catapult.utils;
 
+const rawUint64ToUint64 = value => (value instanceof Binary ? uint64.fromBytes(value.buffer) : longToUint64(value));
+
 module.exports = {
 	[ModelType.none]: value => value,
 	// `binary` should support both mongo binary buffers and intermediate js buffers
@@ -33,5 +35,6 @@ module.exports = {
 	[ModelType.statusCode]: value => status.toString(value >>> 0),
 	[ModelType.string]: value => value.toString(),
 	[ModelType.uint16]: value => (value instanceof Binary ? Buffer.from(value.buffer).readInt16LE(0) : value),
-	[ModelType.uint64]: value => (value instanceof Binary ? uint64.fromBytes(value.buffer) : longToUint64(value))
+	[ModelType.uint64]: value => rawUint64ToUint64(value),
+	[ModelType.uint64String]: value => uint64.toString(rawUint64ToUint64(value))
 };

--- a/rest/src/server/messageFormattingRules.js
+++ b/rest/src/server/messageFormattingRules.js
@@ -21,7 +21,7 @@
 const catapult = require('catapult-sdk');
 
 const { ModelType, status } = catapult.model;
-const { convert } = catapult.utils;
+const { convert, uint64 } = catapult.utils;
 
 module.exports = {
 	[ModelType.none]: value => value,
@@ -29,5 +29,6 @@ module.exports = {
 	[ModelType.statusCode]: status.toString,
 	[ModelType.string]: value => value.toString(),
 	[ModelType.uint16]: value => value,
-	[ModelType.uint64]: value => value
+	[ModelType.uint64]: value => value,
+	[ModelType.uint64String]: value => uint64.toString(value)
 };

--- a/rest/test/db/dbFormattingRules_spec.js
+++ b/rest/test/db/dbFormattingRules_spec.js
@@ -139,4 +139,29 @@ describe('db formatting rules', () => {
 		// Assert:
 		expect(result).to.deep.equal([0x00ABCDEF, 0x000FDFFF]);
 	});
+
+	it('can format uint64String type from Long', () => {
+		// Arrange:
+		const object = convertToLong([1, 2]);
+
+		// Act:
+		const result = formattingRules[ModelType.uint64String](object);
+
+		// Assert:
+		expect(result).to.deep.equal('8589934593');
+	});
+
+	it('can format uint64String type from Binary', () => {
+		// Arrange:
+		const buffer = Buffer.alloc(8, 0);
+		buffer.writeUInt32LE(0x00ABCDEF, 0);
+		buffer.writeUInt32LE(0x000FDFFF, 4);
+		const object = new Binary(buffer);
+
+		// Act:
+		const result = formattingRules[ModelType.uint64String](object);
+
+		// Assert:
+		expect(result).to.deep.equal('4468410971573743');
+	});
 });

--- a/rest/test/server/messageFormattingRules_spec.js
+++ b/rest/test/server/messageFormattingRules_spec.js
@@ -96,4 +96,15 @@ describe('message formatting rules', () => {
 		// Assert:
 		expect(result).to.deep.equal([1, 2]);
 	});
+
+	it('can format uint64String type', () => {
+		// Arrange:
+		const object = [1, 2];
+
+		// Act:
+		const result = formattingRules[ModelType.uint64String](object);
+
+		// Assert:
+		expect(result).to.deep.equal('8589934593');
+	});
 });


### PR DESCRIPTION
Required for #84 

This enhancement does not break backward compatibility, hence the early partial PR.

The idea would be to have an extra formatter option (uint64String), and update the current (uint64) one so that it formats to HEX instead of an old uint64 two-valued array. Every uint64 value output by REST would be represented in HEX, excluding a few select ones represented by uint64String (mosaic and namespace identifiers).

Open for renaming suggestions (uint64NumericString, uint64Identifier, etc)
