### PR TITLE
Updated chainStatistic schema

### DIFF
--- a/catapult-sdk/src/model/ModelFormatterBuilder.js
+++ b/catapult-sdk/src/model/ModelFormatterBuilder.js
@@ -39,6 +39,7 @@ class ModelFormatterBuilder {
 			'transactionWithMetadata',
 
 			'chainStatistic',
+			'chainStatisticCurrent',
 			'merkleProofInfo',
 			'nodeInfo',
 			'nodeTime',

--- a/catapult-sdk/src/model/ModelSchemaBuilder.js
+++ b/catapult-sdk/src/model/ModelSchemaBuilder.js
@@ -134,6 +134,9 @@ class ModelSchemaBuilder {
 			// region other
 
 			chainStatistic: {
+				current: { type: ModelType.object, schemaName: 'chainStatisticCurrent' }
+			},
+			chainStatisticCurrent: {
 				height: ModelType.uint64,
 				scoreLow: ModelType.uint64,
 				scoreHigh: ModelType.uint64

--- a/catapult-sdk/test/model/ModelFormatterBuilder_spec.js
+++ b/catapult-sdk/test/model/ModelFormatterBuilder_spec.js
@@ -48,6 +48,7 @@ describe('model formatter builder', () => {
 				'transactionWithMetadata',
 
 				'chainStatistic',
+				'chainStatisticCurrent',
 				'merkleProofInfo',
 				'nodeInfo',
 				'nodeTime',
@@ -202,16 +203,20 @@ describe('model formatter builder', () => {
 
 			// Act:
 			const result = formatter.chainStatistic.format({
-				height: 0,
-				scoreLow: 0,
-				scoreHigh: 0
+				current: {
+					height: 0,
+					scoreLow: 0,
+					scoreHigh: 0
+				}
 			});
 
 			// Assert:
 			expect(result).to.deep.equal({
-				height: 'uint64',
-				scoreLow: 'uint64',
-				scoreHigh: 'uint64'
+				current: {
+					height: 'uint64',
+					scoreLow: 'uint64',
+					scoreHigh: 'uint64'
+				}
 			});
 		});
 

--- a/catapult-sdk/test/model/ModelSchemaBuilder_spec.js
+++ b/catapult-sdk/test/model/ModelSchemaBuilder_spec.js
@@ -87,6 +87,7 @@ describe('model schema builder', () => {
 				'accountWithMetadata',
 
 				'chainStatistic',
+				'chainStatisticCurrent',
 				'nodeInfo',
 				'communicationTimestamps',
 				'nodeTime',
@@ -149,6 +150,8 @@ describe('model schema builder', () => {
 
 				'accountWithMetadata.meta',
 				'accountWithMetadata.account',
+
+				'chainStatistic.current',
 
 				'nodeTime.communicationTimestamps'
 			]);
@@ -231,9 +234,9 @@ describe('model schema builder', () => {
 				'mosaic.id',
 				'mosaic.amount',
 
-				'chainStatistic.height',
-				'chainStatistic.scoreLow',
-				'chainStatistic.scoreHigh',
+				'chainStatisticCurrent.height',
+				'chainStatisticCurrent.scoreLow',
+				'chainStatisticCurrent.scoreHigh',
 
 				'communicationTimestamps.receiveTimestamp',
 				'communicationTimestamps.sendTimestamp'

--- a/catapult-sdk/test/plugins/catapultModelSystem_spec.js
+++ b/catapult-sdk/test/plugins/catapultModelSystem_spec.js
@@ -193,9 +193,9 @@ describe('catapult model system', () => {
 			});
 
 			// - formatting rules are dependent on formatter
-			const chainStatistic = { current: { height: [123, 456] }};
-			expect(system.formatters.default.chainStatistic.format(chainStatistic)).to.deep.equal({ current: { height: 'uint64' }});
-			expect(system.formatters.custom.chainStatistic.format(chainStatistic)).to.deep.equal({ current: { height: 123 }});
+			const chainStatistic = { current: { height: [123, 456] } };
+			expect(system.formatters.default.chainStatistic.format(chainStatistic)).to.deep.equal({ current: { height: 'uint64' } });
+			expect(system.formatters.custom.chainStatistic.format(chainStatistic)).to.deep.equal({ current: { height: 123 } });
 		});
 	});
 });

--- a/catapult-sdk/test/plugins/catapultModelSystem_spec.js
+++ b/catapult-sdk/test/plugins/catapultModelSystem_spec.js
@@ -193,9 +193,9 @@ describe('catapult model system', () => {
 			});
 
 			// - formatting rules are dependent on formatter
-			const chainStatistic = { height: [123, 456] };
-			expect(system.formatters.default.chainStatistic.format(chainStatistic)).to.deep.equal({ height: 'uint64' });
-			expect(system.formatters.custom.chainStatistic.format(chainStatistic)).to.deep.equal({ height: 123 });
+			const chainStatistic = { current: { height: [123, 456] }};
+			expect(system.formatters.default.chainStatistic.format(chainStatistic)).to.deep.equal({ current: { height: 'uint64' }});
+			expect(system.formatters.custom.chainStatistic.format(chainStatistic)).to.deep.equal({ current: { height: 123 }});
 		});
 	});
 });

--- a/rest/src/db/CatapultDb.js
+++ b/rest/src/db/CatapultDb.js
@@ -183,6 +183,11 @@ class CatapultDb {
 		return this.queryDocument('chainStatistic', {}, { _id: 0 });
 	}
 
+	chainStatisticCurrent() {
+		return this.queryDocument('chainStatistic', {}, { _id: 0 })
+			.then(chainStatistic => chainStatistic.current);
+	}
+
 	blockAtHeight(height) {
 		return this.queryDocument(
 			'blocks',
@@ -204,7 +209,7 @@ class CatapultDb {
 		if (0 === numBlocks)
 			return Promise.resolve([]);
 
-		return this.chainStatistic().then(chainStatistic => {
+		return this.chainStatisticCurrent().then(chainStatistic => {
 			const blockCollection = this.database.collection('blocks');
 			const options = buildBlocksFromOptions(convertToLong(height), convertToLong(numBlocks), chainStatistic.height);
 

--- a/rest/src/routes/chainRoutes.js
+++ b/rest/src/routes/chainRoutes.js
@@ -29,16 +29,16 @@ const curryStripProperties = (properties, next) => chainStatistic => {
 };
 
 const currySend = (db, res, next) => chainStatistic => {
-	res.send({ payload: chainStatistic, type: routeResultTypes.chainStatistic });
+	res.send({ payload: chainStatistic, type: routeResultTypes.chainStatisticCurrent });
 	next();
 };
 
 module.exports = {
 	register: (server, db) => {
 		server.get('/chain/height', (req, res, next) =>
-			db.chainStatistic().then(curryStripProperties(['scoreLow', 'scoreHigh'], currySend(db, res, next))));
+			db.chainStatisticCurrent().then(curryStripProperties(['scoreLow', 'scoreHigh'], currySend(db, res, next))));
 
 		server.get('/chain/score', (req, res, next) =>
-			db.chainStatistic().then(curryStripProperties(['height'], currySend(db, res, next))));
+			db.chainStatisticCurrent().then(curryStripProperties(['height'], currySend(db, res, next))));
 	}
 };

--- a/rest/src/routes/dbFacade.js
+++ b/rest/src/routes/dbFacade.js
@@ -38,7 +38,7 @@ module.exports = {
 	runHeightDependentOperation: (db, height, operation) => {
 		// notice that both the chain height and height-dependent operation are started at the same time in order to
 		// optimize the common case when the request height is valid
-		const chainStatisticPromise = db.chainStatistic();
+		const chainStatisticPromise = db.chainStatisticCurrent();
 		const operationPromise = operation();
 
 		return Promise.all([chainStatisticPromise, operationPromise]).then(results => {

--- a/rest/src/routes/routeResultTypes.js
+++ b/rest/src/routes/routeResultTypes.js
@@ -26,6 +26,7 @@ module.exports = {
 
 	// other
 	chainStatistic: 'chainStatistic',
+	chainStatisticCurrent: 'chainStatisticCurrent',
 	merkleProofInfo: 'merkleProofInfo',
 	receipts: 'receipts',
 	transactionStatus: 'transactionStatus',

--- a/rest/test/db/CatapultDb_spec.js
+++ b/rest/test/db/CatapultDb_spec.js
@@ -286,7 +286,8 @@ describe('catapult db', () => {
 				createDbEntities(1),
 				db => db.blocksFrom(Long.fromNumber(Default_Height + 1), 10),
 				blocks => expect(blocks).to.deep.equal([])
-			));
+			)
+		);
 
 		const assertBlocks = (actualBlocks, dbEntities, startHeight, numBlocks) => {
 			// Assert: actual blocks should contain `numBlocks` blocks from `startHeight`.

--- a/rest/test/db/CatapultDb_spec.js
+++ b/rest/test/db/CatapultDb_spec.js
@@ -286,8 +286,7 @@ describe('catapult db', () => {
 				createDbEntities(1),
 				db => db.blocksFrom(Long.fromNumber(Default_Height + 1), 10),
 				blocks => expect(blocks).to.deep.equal([])
-			)
-		);
+			));
 
 		const assertBlocks = (actualBlocks, dbEntities, startHeight, numBlocks) => {
 			// Assert: actual blocks should contain `numBlocks` blocks from `startHeight`.

--- a/rest/test/db/utils/dbTestUtils.js
+++ b/rest/test/db/utils/dbTestUtils.js
@@ -190,9 +190,11 @@ const createDbTransactions = (numRounds, signerPublicKey, recipientAddress) => {
 };
 
 const createChainStatistic = (height, scorelow, scoreHigh) => ({
-	height: Long.fromNumber(height),
-	scoreLow: Long.fromNumber(scorelow),
-	scoreHigh: Long.fromNumber(scoreHigh)
+	current: {
+		height: Long.fromNumber(height),
+		scoreLow: Long.fromNumber(scorelow),
+		scoreHigh: Long.fromNumber(scoreHigh)
+	}
 });
 
 const collectionUtils = {

--- a/rest/test/plugins/receipts/receiptsRoutes_spec.js
+++ b/rest/test/plugins/receipts/receiptsRoutes_spec.js
@@ -44,7 +44,7 @@ describe('receipts routes', () => {
 
 		receiptsRoutes.register(mockServer.server, {
 			catapultDb: {
-				chainStatistic: () => Promise.resolve({ height: highestHeight })
+				chainStatisticCurrent: () => Promise.resolve({ height: highestHeight })
 			},
 			statementsAtHeight: statementsFake
 		});

--- a/rest/test/routes/blockRoutes_spec.js
+++ b/rest/test/routes/blockRoutes_spec.js
@@ -25,7 +25,7 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 
 describe('block routes', () => {
-	const addChainStatisticToDb = db => { db.chainStatistic = () => Promise.resolve({ height: 10 }); };
+	const addChainStatisticToDb = db => { db.chainStatisticCurrent = () => Promise.resolve({ height: 10 }); };
 	const routeConfig = { pageSize: { min: 30, max: 80, step: 12 } };
 
 	describe('block', () => {
@@ -112,7 +112,7 @@ describe('block routes', () => {
 							queriedIdentifiers.push({ height, pageId, pageSize });
 							return Promise.resolve(transactions);
 						},
-						chainStatistic: () => Promise.resolve({ height: 10 })
+						chainStatisticCurrent: () => Promise.resolve({ height: 10 })
 					}),
 					config: routeConfig
 				},

--- a/rest/test/routes/chainRoutes_spec.js
+++ b/rest/test/routes/chainRoutes_spec.js
@@ -28,7 +28,7 @@ describe('chain routes', () => {
 
 	describe('get', () => {
 		const createMockChainStatisticDb = (height, scoreLow, scoreHigh) => ({
-			chainStatistic: () => Promise.resolve({ height, scoreLow, scoreHigh })
+			chainStatisticCurrent: () => Promise.resolve({ height, scoreLow, scoreHigh })
 		});
 
 		it('can retrieve height', () => {
@@ -38,7 +38,7 @@ describe('chain routes', () => {
 			// Act:
 			return executeRoute('/chain/height', db, response => {
 				// Assert:
-				expect(response).to.deep.equal({ payload: { height: 2 }, type: 'chainStatistic' });
+				expect(response).to.deep.equal({ payload: { height: 2 }, type: 'chainStatisticCurrent' });
 			});
 		});
 
@@ -49,7 +49,7 @@ describe('chain routes', () => {
 			// Act:
 			return executeRoute('/chain/score', db, response => {
 				// Assert:
-				expect(response).to.deep.equal({ payload: { scoreLow: 64, scoreHigh: 9 }, type: 'chainStatistic' });
+				expect(response).to.deep.equal({ payload: { scoreLow: 64, scoreHigh: 9 }, type: 'chainStatisticCurrent' });
 			});
 		});
 	});

--- a/rest/test/routes/dbFacade_spec.js
+++ b/rest/test/routes/dbFacade_spec.js
@@ -25,7 +25,7 @@ describe('db facade', () => {
 	describe('run height dependent operation', () => {
 		const runHeightDependentOperationTest = (requestHeight, chainHeight, isRequestValid) => {
 			// Arrange:
-			const db = { chainStatistic: () => Promise.resolve({ height: chainHeight }) };
+			const db = { chainStatisticCurrent: () => Promise.resolve({ height: chainHeight }) };
 
 			// Act:
 			return dbFacade.runHeightDependentOperation(db, requestHeight, () => Promise.resolve(17))

--- a/rest/test/routes/routeResultTypes_spec.js
+++ b/rest/test/routes/routeResultTypes_spec.js
@@ -23,12 +23,13 @@ const { expect } = require('chai');
 
 describe('routeResultTypes', () => {
 	it('has correct links to schema', () => {
-		expect(Object.keys(routeResultTypes).length).to.equal(11);
+		expect(Object.keys(routeResultTypes).length).to.equal(12);
 		expect(routeResultTypes).to.deep.equal({
 			account: 'accountWithMetadata',
 			block: 'blockHeaderWithMetadata',
 			transaction: 'transactionWithMetadata',
 			chainStatistic: 'chainStatistic',
+			chainStatisticCurrent: 'chainStatisticCurrent',
 			merkleProofInfo: 'merkleProofInfo',
 			receipts: 'receipts',
 			transactionStatus: 'transactionStatus',

--- a/rest/test/routes/routeUtils_spec.js
+++ b/rest/test/routes/routeUtils_spec.js
@@ -482,7 +482,7 @@ describe('route utils', () => {
 		blockInfoMockData.meta[blockMetaTreeField] = merkleTree;
 
 		const db = {
-			chainStatistic: () => Promise.resolve({ height: highestHeight }),
+			chainStatisticCurrent: () => Promise.resolve({ height: highestHeight }),
 			blockWithMerkleTreeAtHeight: () => Promise.resolve(blockInfoMockData)
 		};
 

--- a/rest/test/server/bootstrapper_spec.js
+++ b/rest/test/server/bootstrapper_spec.js
@@ -85,7 +85,7 @@ const addRestRoutes = server => {
 				return undefined; // don't call next below because it is called by res.redirect
 
 			case dummyIds.asyncValid:
-				return Promise.resolve({ current: { height: [11, 11] }})
+				return Promise.resolve({ current: { height: [11, 11] } })
 					.then(chainStatistic => {
 						res.send({ payload: chainStatistic, type: 'chainStatistic' });
 						next();
@@ -289,7 +289,7 @@ describe('server (bootstrapper)', () => {
 					.end((headers, body) => {
 						// Assert:
 						assertPayloadHeaders(headers, 29, methodOptions);
-						expect(body).to.deep.equal({ current: { height: [11, 0] }});
+						expect(body).to.deep.equal({ current: { height: [11, 0] } });
 						done();
 					});
 			});

--- a/rest/test/server/bootstrapper_spec.js
+++ b/rest/test/server/bootstrapper_spec.js
@@ -48,9 +48,11 @@ const dummyIds = {
 // note that custom formatting will strip high part
 const createChainStatistic = (height, scoreLow, scoreHigh) => ({
 	id: 123,
-	height: [height, height],
-	scoreLow: [scoreLow, scoreLow],
-	scoreHigh: [scoreHigh, scoreHigh]
+	current: {
+		height: [height, height],
+		scoreLow: [scoreLow, scoreLow],
+		scoreHigh: [scoreHigh, scoreHigh]
+	}
 });
 
 const addRestRoutes = server => {
@@ -83,7 +85,7 @@ const addRestRoutes = server => {
 				return undefined; // don't call next below because it is called by res.redirect
 
 			case dummyIds.asyncValid:
-				return Promise.resolve({ height: [11, 11] })
+				return Promise.resolve({ current: { height: [11, 11] }})
 					.then(chainStatistic => {
 						res.send({ payload: chainStatistic, type: 'chainStatistic' });
 						next();
@@ -114,11 +116,15 @@ const createServer = options => {
 				// real formatting is not actually being tested, so just drop high part
 				format: chainStatistic => {
 					const formatUint64 = uint64 => (uint64 ? [uint64[0], 0] : undefined);
+					const formatChainStatisticCurrent = chainStatisticCurrent => ({
+						height: formatUint64(chainStatisticCurrent.height),
+						scoreLow: formatUint64(chainStatisticCurrent.scoreLow),
+						scoreHigh: formatUint64(chainStatisticCurrent.scoreHigh)
+					});
+
 					return {
 						id: chainStatistic.id,
-						height: formatUint64(chainStatistic.height),
-						scoreLow: formatUint64(chainStatistic.scoreLow),
-						scoreHigh: formatUint64(chainStatistic.scoreHigh)
+						current: formatChainStatisticCurrent(chainStatistic.current)
 					};
 				}
 			},
@@ -228,9 +234,10 @@ describe('server (bootstrapper)', () => {
 					.expectStatus(200)
 					.end((headers, body) => {
 						// Assert:
-						assertPayloadHeaders(headers, 63, methodOptions);
+						assertPayloadHeaders(headers, 75, methodOptions);
 						expect(body).to.deep.equal({
-							id: 123, height: [10, 0], scoreLow: [16, 0], scoreHigh: [11, 0]
+							id: 123,
+							current: { height: [10, 0], scoreLow: [16, 0], scoreHigh: [11, 0] }
 						});
 						done();
 					});
@@ -241,9 +248,10 @@ describe('server (bootstrapper)', () => {
 					.expectStatus(200)
 					.end((headers, body) => {
 						// Assert:
-						assertPayloadHeaders(headers, 63, methodOptions);
+						assertPayloadHeaders(headers, 75, methodOptions);
 						expect(body).to.deep.equal({
-							id: 123, height: [25, 0], scoreLow: [25, 0], scoreHigh: [25, 0]
+							id: 123,
+							current: { height: [25, 0], scoreLow: [25, 0], scoreHigh: [25, 0] }
 						});
 						done();
 					});
@@ -280,8 +288,8 @@ describe('server (bootstrapper)', () => {
 					.expectStatus(200)
 					.end((headers, body) => {
 						// Assert:
-						assertPayloadHeaders(headers, 17, methodOptions);
-						expect(body).to.deep.equal({ height: [11, 0] });
+						assertPayloadHeaders(headers, 29, methodOptions);
+						expect(body).to.deep.equal({ current: { height: [11, 0] }});
 						done();
 					});
 			});
@@ -333,9 +341,10 @@ describe('server (bootstrapper)', () => {
 					.expectStatus(200)
 					.end((headers, body) => {
 						// Assert:
-						assertPayloadHeaders(headers, 63, { allowMethods: undefined });
+						assertPayloadHeaders(headers, 75, { allowMethods: undefined });
 						expect(body).to.deep.equal({
-							id: 123, height: [10, 0], scoreLow: [16, 0], scoreHigh: [11, 0]
+							id: 123,
+							current: { height: [10, 0], scoreLow: [16, 0], scoreHigh: [11, 0] }
 						});
 						done();
 					});
@@ -346,9 +355,10 @@ describe('server (bootstrapper)', () => {
 					.expectStatus(200)
 					.end((headers, body) => {
 						// Assert:
-						assertPayloadHeaders(headers, 63, { allowMethods: `FOO,${method.toUpperCase()},BAR` });
+						assertPayloadHeaders(headers, 75, { allowMethods: `FOO,${method.toUpperCase()},BAR` });
 						expect(body).to.deep.equal({
-							id: 123, height: [10, 0], scoreLow: [16, 0], scoreHigh: [11, 0]
+							id: 123,
+							current: { height: [10, 0], scoreLow: [16, 0], scoreHigh: [11, 0] }
 						});
 						done();
 					});
@@ -416,9 +426,10 @@ describe('server (bootstrapper)', () => {
 					.expectStatus(200)
 					.end((headers, body) => {
 						// Assert:
-						assertPayloadHeaders(headers, 63, {});
+						assertPayloadHeaders(headers, 75, {});
 						expect(body).to.deep.equal({
-							id: 123, height: [25, 0], scoreLow: [25, 0], scoreHigh: [25, 0]
+							id: 123,
+							current: { height: [25, 0], scoreLow: [25, 0], scoreHigh: [25, 0] }
 						});
 						done();
 					});

--- a/rest/test/server/formatters_spec.js
+++ b/rest/test/server/formatters_spec.js
@@ -23,15 +23,22 @@ const { expect } = require('chai');
 
 describe('formatters', () => {
 	const createFormatters = name => {
-		const formatUint64 = uint64 => (uint64 ? [uint64[0], uint64[1] * 2] : undefined);
 		return formatters.create({
 			[name]: {
 				chainStatistic: {
-					format: chainStatistic => ({
-						height: formatUint64(chainStatistic.height),
-						scoreLow: formatUint64(chainStatistic.scoreLow),
-						scoreHigh: formatUint64(chainStatistic.scoreHigh)
-					})
+					format: chainStatistic => {
+						const formatUint64 = uint64 => (uint64 ? [uint64[0], uint64[1] * 2] : undefined);
+						const formatChainStatisticCurrent = chainStatisticCurrent => ({
+							height: formatUint64(chainStatisticCurrent.height),
+							scoreLow: formatUint64(chainStatisticCurrent.scoreLow),
+							scoreHigh: formatUint64(chainStatisticCurrent.scoreHigh)
+						});
+
+						return {
+							id: chainStatistic.id,
+							current: formatChainStatisticCurrent(chainStatistic.current)
+						};
+					}
 				}
 			}
 		});
@@ -60,29 +67,31 @@ describe('formatters', () => {
 			// Arrange:
 			const object = {
 				payload: {
-					height: [1, 2],
-					scoreLow: [112233, 8899],
-					scoreHigh: [4, 3]
+					current: {
+						height: [1, 2],
+						scoreLow: [112233, 8899],
+						scoreHigh: [4, 3]
+					}
 				},
 				type: 'chainStatistic'
 			};
 
 			// Assert: formatter doubles high part
-			assertJsonFormat(object, '{"height":[1,4],"scoreLow":[112233,17798],"scoreHigh":[4,6]}', undefined);
+			assertJsonFormat(object, '{"current":{"height":[1,4],"scoreLow":[112233,17798],"scoreHigh":[4,6]}}', undefined);
 		});
 
 		it('can format catapult object array', () => {
 			// Arrange:
 			const object = {
 				payload: [
-					{ height: [1, 2] },
-					{ height: [8, 7] }
+					{ current: { height: [1, 2] }},
+					{ current: { height: [8, 7] }}
 				],
 				type: 'chainStatistic'
 			};
 
 			// Assert: formatter doubles high part
-			assertJsonFormat(object, '[{"height":[1,4]},{"height":[8,14]}]', undefined);
+			assertJsonFormat(object, '[{"current":{"height":[1,4]}},{"current":{"height":[8,14]}}]', undefined);
 		});
 
 		// endregion

--- a/rest/test/server/formatters_spec.js
+++ b/rest/test/server/formatters_spec.js
@@ -22,27 +22,25 @@ const formatters = require('../../src/server/formatters');
 const { expect } = require('chai');
 
 describe('formatters', () => {
-	const createFormatters = name => {
-		return formatters.create({
-			[name]: {
-				chainStatistic: {
-					format: chainStatistic => {
-						const formatUint64 = uint64 => (uint64 ? [uint64[0], uint64[1] * 2] : undefined);
-						const formatChainStatisticCurrent = chainStatisticCurrent => ({
-							height: formatUint64(chainStatisticCurrent.height),
-							scoreLow: formatUint64(chainStatisticCurrent.scoreLow),
-							scoreHigh: formatUint64(chainStatisticCurrent.scoreHigh)
-						});
+	const createFormatters = name => formatters.create({
+		[name]: {
+			chainStatistic: {
+				format: chainStatistic => {
+					const formatUint64 = uint64 => (uint64 ? [uint64[0], uint64[1] * 2] : undefined);
+					const formatChainStatisticCurrent = chainStatisticCurrent => ({
+						height: formatUint64(chainStatisticCurrent.height),
+						scoreLow: formatUint64(chainStatisticCurrent.scoreLow),
+						scoreHigh: formatUint64(chainStatisticCurrent.scoreHigh)
+					});
 
-						return {
-							id: chainStatistic.id,
-							current: formatChainStatisticCurrent(chainStatistic.current)
-						};
-					}
+					return {
+						id: chainStatistic.id,
+						current: formatChainStatisticCurrent(chainStatistic.current)
+					};
 				}
 			}
-		});
-	};
+		}
+	});
 
 	const addBasicObjectFormattingTests = assertJsonFormat => {
 		// region non-error
@@ -84,8 +82,8 @@ describe('formatters', () => {
 			// Arrange:
 			const object = {
 				payload: [
-					{ current: { height: [1, 2] }},
-					{ current: { height: [8, 7] }}
+					{ current: { height: [1, 2] } },
+					{ current: { height: [8, 7] } }
 				],
 				type: 'chainStatistic'
 			};


### PR DESCRIPTION
with changes to chainStatistic schema chain endpoints, and chain related endpoints (dependent on `height`) are failing

as  discussed with @dgarcia360  we left the `/chain/info` endpoint with the full schema info (including `current` structure, and specific endpoints (`/chain/height` and `/chain/score`) with just inner `current` information