### PR TITLE
Fixed schema name and long convertion for mosaics ids

### DIFF
--- a/catapult-sdk/src/plugins/namespace.js
+++ b/catapult-sdk/src/plugins/namespace.js
@@ -65,6 +65,7 @@ const namespacePlugin = {
 			meta: { type: ModelType.object, schemaName: 'transactionMetadata' },
 			namespace: { type: ModelType.object, schemaName: 'namespaceDescriptor.namespace' }
 		});
+
 		builder.addSchema('namespaceDescriptor.namespace', {
 			level0: ModelType.uint64HexIdentifier,
 			level1: ModelType.uint64HexIdentifier,
@@ -96,7 +97,7 @@ const namespacePlugin = {
 			parentId: ModelType.uint64HexIdentifier
 		});
 
-		builder.addSchema('mosaicNamesTuples', {
+		builder.addSchema('mosaicNames', {
 			mosaicNames: { type: ModelType.array, schemaName: 'mosaicNamesTuple' }
 		});
 
@@ -105,7 +106,7 @@ const namespacePlugin = {
 			names: { type: ModelType.array, schemaName: ModelType.string }
 		});
 
-		builder.addSchema('accountNamesTuples', {
+		builder.addSchema('accountNames', {
 			accountNames: { type: ModelType.array, schemaName: 'accountNamesTuple' }
 		});
 

--- a/catapult-sdk/test/plugins/namespace_spec.js
+++ b/catapult-sdk/test/plugins/namespace_spec.js
@@ -58,9 +58,9 @@ describe('namespace plugin', () => {
 				'namespaceDescriptor.alias.empty',
 				'namespaceNameTuple',
 				'registerNamespace',
-				'mosaicNamesTuples',
+				'mosaicNames',
 				'mosaicNamesTuple',
-				'accountNamesTuples',
+				'accountNames',
 				'accountNamesTuple'
 			);
 
@@ -105,17 +105,17 @@ describe('namespace plugin', () => {
 			expect(Object.keys(modelSchema.registerNamespace).length).to.equal(Object.keys(modelSchema.transaction).length + 4);
 			expect(modelSchema.registerNamespace).to.contain.all.keys(['id', 'parentId', 'duration', 'name']);
 
-			// - mosaic names tuples
-			expect(Object.keys(modelSchema.mosaicNamesTuples).length).to.equal(1);
-			expect(modelSchema.mosaicNamesTuples).to.contain.all.keys(['mosaicNames']);
+			// - mosaic names
+			expect(Object.keys(modelSchema.mosaicNames).length).to.equal(1);
+			expect(modelSchema.mosaicNames).to.contain.all.keys(['mosaicNames']);
 
 			// - mosaic names tuple
 			expect(Object.keys(modelSchema.mosaicNamesTuple).length).to.equal(2);
 			expect(modelSchema.mosaicNamesTuple).to.contain.all.keys(['mosaicId', 'names']);
 
-			// - account names tuples
-			expect(Object.keys(modelSchema.accountNamesTuples).length).to.equal(1);
-			expect(modelSchema.accountNamesTuples).to.contain.all.keys(['accountNames']);
+			// - account names
+			expect(Object.keys(modelSchema.accountNames).length).to.equal(1);
+			expect(modelSchema.accountNames).to.contain.all.keys(['accountNames']);
 
 			// - account names tuple
 			expect(Object.keys(modelSchema.accountNamesTuple).length).to.equal(2);

--- a/rest/src/plugins/namespace/namespaceRoutes.js
+++ b/rest/src/plugins/namespace/namespaceRoutes.js
@@ -65,7 +65,7 @@ module.exports = {
 
 		const collectNames = (namespaceNameTuples, namespaceIds) => {
 			const type = catapult.model.EntityType.registerNamespace;
-			return db.catapultDb.findNamesByIds(namespaceIds, type, { id: 'namespaceId', name: 'name', parentId: 'parentId' })
+			return db.catapultDb.findNamesByIds(namespaceIds, type, { id: 'id', name: 'name', parentId: 'parentId' })
 				.then(nameTuples => {
 					nameTuples.forEach(nameTuple => {
 						// db returns null instead of undefined when parentId is not present

--- a/rest/src/plugins/namespace/namespaceRoutes.js
+++ b/rest/src/plugins/namespace/namespaceRoutes.js
@@ -105,7 +105,7 @@ module.exports = {
 			req => routeUtils.parseArgumentAsArray(req.params, 'mosaicIds', uint64.fromHex),
 			(namespace, id) => namespace.namespace.alias.mosaicId.equals(convertToLong(id)),
 			'mosaicId',
-			'mosaicNamesTuples'
+			'mosaicNames'
 		));
 
 		const accountIdToAddress = (type, accountId) => ((AccountType.publicKey === type)
@@ -132,7 +132,7 @@ module.exports = {
 			(namespace, id) => Buffer.from(namespace.namespace.alias.address.value())
 				.equals(Buffer.from(new Binary(Buffer.from(id)).value())),
 			'address',
-			'accountNamesTuples',
+			'accountNames',
 		));
 	}
 };

--- a/rest/src/plugins/namespace/namespaceUtils.js
+++ b/rest/src/plugins/namespace/namespaceUtils.js
@@ -17,6 +17,10 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
+const dbUtils = require('../../db/dbUtils');
+const catapult = require('catapult-sdk');
+
+const { convertToLong } = dbUtils;
 
 const namespaceUtils = {
 	/**
@@ -86,10 +90,14 @@ const namespaceUtils = {
 								aliasName += `.${uniqueTransactions.find(t => t.namespaceId.equals(n.namespace.level2)).name}`;
 							names.push(aliasName);
 						});
-					return { [aliasFieldName]: id, names };
+					return {
+						[aliasFieldName]: aliasType === catapult.model.namespace.aliasType.mosaic ? convertToLong(id) : id,
+						names
+					};
 				});
 
-				res.send({ payload: { accountNames: namesTuples }, type: schemaName });
+				res.send({ payload: { [schemaName]: namesTuples }, type: schemaName });
+
 				return next();
 			});
 		});

--- a/rest/test/plugins/namespace/namespaceRoutes_spec.js
+++ b/rest/test/plugins/namespace/namespaceRoutes_spec.js
@@ -186,7 +186,7 @@ describe('namespace routes', () => {
 			// 1. in db, parentId is only stored for child namespaces
 			// 2. db returns null instead of undefined when a document property is not present
 			parentId: undefined === parentId ? null : createParentId(parentId),
-			namespaceId: [0, namespaceId]
+			id: [0, namespaceId]
 		});
 
 		const Valid_Hex_String_Namespace_Ids = ['1234567890ABCDEF', 'ABCDEF0123456789'];
@@ -222,7 +222,7 @@ describe('namespace routes', () => {
 					dbParamTuples.forEach(dbParamTuple => {
 						expect(dbParamTuple.ids).to.deep.equal(options.queryIdsGroupedByLevel[level++]);
 						expect(dbParamTuple.transactionType).to.deep.equal(catapult.model.EntityType.registerNamespace);
-						expect(dbParamTuple.fieldsDescriptor).to.deep.equal({ id: 'namespaceId', name: 'name', parentId: 'parentId' });
+						expect(dbParamTuple.fieldsDescriptor).to.deep.equal({ id: 'id', name: 'name', parentId: 'parentId' });
 					});
 
 					// check response

--- a/rest/test/plugins/namespace/namespaceRoutes_spec.js
+++ b/rest/test/plugins/namespace/namespaceRoutes_spec.js
@@ -301,7 +301,7 @@ describe('namespace routes', () => {
 				expect(aliasNamesRoutesProcessorSpy.calledTwice).to.equal(true);
 				expect(aliasNamesRoutesProcessorSpy.firstCall.args[1]).to.equal(catapult.model.namespace.aliasType.mosaic);
 				expect(aliasNamesRoutesProcessorSpy.firstCall.args[4]).to.equal('mosaicId');
-				expect(aliasNamesRoutesProcessorSpy.firstCall.args[5]).to.equal('mosaicNamesTuples');
+				expect(aliasNamesRoutesProcessorSpy.firstCall.args[5]).to.equal('mosaicNames');
 
 				aliasNamesRoutesProcessorSpy.restore();
 			});
@@ -398,7 +398,7 @@ describe('namespace routes', () => {
 				expect(aliasNamesRoutesProcessorSpy.calledTwice).to.equal(true);
 				expect(aliasNamesRoutesProcessorSpy.secondCall.args[1]).to.equal(catapult.model.namespace.aliasType.address);
 				expect(aliasNamesRoutesProcessorSpy.secondCall.args[4]).to.equal('address');
-				expect(aliasNamesRoutesProcessorSpy.secondCall.args[5]).to.equal('accountNamesTuples');
+				expect(aliasNamesRoutesProcessorSpy.secondCall.args[5]).to.equal('accountNames');
 
 				aliasNamesRoutesProcessorSpy.restore();
 			});

--- a/rest/test/plugins/namespace/namespaceUtils_spec.js
+++ b/rest/test/plugins/namespace/namespaceUtils_spec.js
@@ -153,9 +153,9 @@ describe('namespace utils', () => {
 				// Assert:
 				expect(sendFake.firstCall.args[0]).to.deep.equal({
 					payload: {
-						accountNames: [
+						testSchemaName: [
 							{
-								[fieldName]: 1,
+								[fieldName]: convertToLong(1),
 								names: [
 									'a',
 									'b.c',
@@ -163,7 +163,7 @@ describe('namespace utils', () => {
 								]
 							},
 							{
-								[fieldName]: 2,
+								[fieldName]: convertToLong(2),
 								names: [
 									'a',
 									'b.c',


### PR DESCRIPTION
Fixes mosaic ids not parsing correctly in **mosaic/names** endpoint.