### PR TITLE
Fixed account address field name in multisig endpoint

### DIFF
--- a/rest/src/plugins/multisig/MultisigDb.js
+++ b/rest/src/plugins/multisig/MultisigDb.js
@@ -39,7 +39,7 @@ class MultisigDb {
 	 */
 	multisigsByAccounts(type, accountIds) {
 		const buffers = accountIds.map(accountId => Buffer.from(accountId));
-		const fieldName = (AccountType.publicKey === type) ? 'multisig.accountPublicKey' : 'multisig.address';
+		const fieldName = (AccountType.publicKey === type) ? 'multisig.accountPublicKey' : 'multisig.accountAddress';
 		return this.catapultDb.queryDocuments('multisigs', { [fieldName]: { $in: buffers } });
 	}
 

--- a/rest/test/plugins/multisig/multisigDbTestUtils.js
+++ b/rest/test/plugins/multisig/multisigDbTestUtils.js
@@ -30,7 +30,7 @@ const createMultisigEntry = (id, owner) => ({
 	_id: dbTestUtils.db.createObjectId(id),
 	multisig: {
 		accountPublicKey: new Binary(owner.publicKey),
-		address: new Binary(owner.address),
+		accountAddress: new Binary(owner.address),
 		cosignatories: [new Binary(test.random.publicKey()), new Binary(test.random.publicKey())],
 		multisigAccounts: [new Binary(test.random.publicKey())]
 	}


### PR DESCRIPTION
Fixes #99.

Based on https://github.com/nemtech/catapult-server/blob/master/scripts/mongo/mongoMultisigDbPrepare.js#L4