### PR TITLE
Removing marker chart from address/topic when status is sent back

### DIFF
--- a/rest/src/connection/MessageChannelBuilder.js
+++ b/rest/src/connection/MessageChannelBuilder.js
@@ -96,8 +96,7 @@ class MessageChannelBuilder {
 				const status = parser.uint32();
 				const deadline = parser.uint64();
 
-				// removing the markerChart from topic.
-				// Format of the address will be 9002AA85058850D31F81F3745F1557E9EC9E9D13A2E1C2B2B0 as byte array.
+				// removing the markerChart from topic
 				const address = topic.subarray(1);
 				emit({
 					type: 'transactionStatus',

--- a/rest/src/connection/MessageChannelBuilder.js
+++ b/rest/src/connection/MessageChannelBuilder.js
@@ -95,10 +95,14 @@ class MessageChannelBuilder {
 				const hash = parser.buffer(catapult.constants.sizes.hash256);
 				const status = parser.uint32();
 				const deadline = parser.uint64();
+
+				// removing the markerChart from topic.
+				// Format of the address will be 9002AA85058850D31F81F3745F1557E9EC9E9D13A2E1C2B2B0 as byte array.
+				const address = topic.subarray(1);
 				emit({
 					type: 'transactionStatus',
 					payload: {
-						hash, address: topic, status, deadline
+						hash, address, status, deadline
 					}
 				});
 			}

--- a/rest/test/connection/MessageChannelBuilder_spec.js
+++ b/rest/test/connection/MessageChannelBuilder_spec.js
@@ -21,7 +21,6 @@
 const MessageChannelBuilder = require('../../src/connection/MessageChannelBuilder');
 const test = require('../testUtils');
 const { expect } = require('chai');
-const catapult = require('catapult-sdk');
 
 describe('message channel builder', () => {
 	const addressTemplate = {
@@ -237,9 +236,7 @@ describe('message channel builder', () => {
 						Buffer.of(55, 0, 0, 0), // status
 						Buffer.of(66, 0, 0, 0, 0, 0, 0, 0) // deadline
 					]);
-					const topicParam = 'SCJFR55L7KWHERD2VW6C3NR2MBZLVDQWDHCHH6ZP';
-					const encodedAddressByteArray = catapult.model.address.stringToAddress(topicParam);
-					const topic = Buffer.concat([Buffer.of('s'.charCodeAt(0)), Buffer.from(encodedAddressByteArray)]);
+					const topic = Buffer.concat([Buffer.of('s'.charCodeAt(0)), addressTemplate.decoded]);
 					handler(codec, eventData => emitted.push(eventData))(topic, buffer, 99);
 
 					// Assert:
@@ -251,7 +248,7 @@ describe('message channel builder', () => {
 						type: 'transactionStatus',
 						payload: {
 							hash: Buffer.alloc(test.constants.sizes.hash256, 41),
-							address: encodedAddressByteArray,
+							address: addressTemplate.decoded,
 							status: 55,
 							deadline: [66, 0]
 						}

--- a/rest/test/connection/MessageChannelBuilder_spec.js
+++ b/rest/test/connection/MessageChannelBuilder_spec.js
@@ -237,7 +237,7 @@ describe('message channel builder', () => {
 						Buffer.of(55, 0, 0, 0), // status
 						Buffer.of(66, 0, 0, 0, 0, 0, 0, 0) // deadline
 					]);
-					const topicParam = "SCJFR55L7KWHERD2VW6C3NR2MBZLVDQWDHCHH6ZP";
+					const topicParam = 'SCJFR55L7KWHERD2VW6C3NR2MBZLVDQWDHCHH6ZP';
 					const encodedAddressByteArray = catapult.model.address.stringToAddress(topicParam);
 					const topic = Buffer.concat([Buffer.of('s'.charCodeAt(0)), Buffer.from(encodedAddressByteArray)]);
 					handler(codec, eventData => emitted.push(eventData))(topic, buffer, 99);

--- a/rest/test/connection/MessageChannelBuilder_spec.js
+++ b/rest/test/connection/MessageChannelBuilder_spec.js
@@ -21,6 +21,7 @@
 const MessageChannelBuilder = require('../../src/connection/MessageChannelBuilder');
 const test = require('../testUtils');
 const { expect } = require('chai');
+const catapult = require('catapult-sdk');
 
 describe('message channel builder', () => {
 	const addressTemplate = {
@@ -236,7 +237,10 @@ describe('message channel builder', () => {
 						Buffer.of(55, 0, 0, 0), // status
 						Buffer.of(66, 0, 0, 0, 0, 0, 0, 0) // deadline
 					]);
-					handler(codec, eventData => emitted.push(eventData))(22, buffer, 99);
+					const topicParam = "SCJFR55L7KWHERD2VW6C3NR2MBZLVDQWDHCHH6ZP";
+					const encodedAddressByteArray = catapult.model.address.stringToAddress(topicParam);
+					const topic = Buffer.concat([Buffer.of('s'.charCodeAt(0)), Buffer.from(encodedAddressByteArray)]);
+					handler(codec, eventData => emitted.push(eventData))(topic, buffer, 99);
 
 					// Assert:
 					// - trailing param 99 should be ignored
@@ -247,7 +251,7 @@ describe('message channel builder', () => {
 						type: 'transactionStatus',
 						payload: {
 							hash: Buffer.alloc(test.constants.sizes.hash256, 41),
-							address: 22,
+							address: encodedAddressByteArray,
 							status: 55,
 							deadline: [66, 0]
 						}


### PR DESCRIPTION
Patch for the https://github.com/nemtech/catapult-rest/issues/141 fix.

