### PR TITLE
Added mosaics keyword wrapper in owned mosaics

### DIFF
--- a/catapult-sdk/src/plugins/mosaic.js
+++ b/catapult-sdk/src/plugins/mosaic.js
@@ -38,6 +38,10 @@ const mosaicPlugin = {
 			delta: ModelType.uint64
 		});
 
+		builder.addSchema('ownedMosaics', {
+			mosaics: { type: ModelType.array, schemaName: 'mosaicDescriptor.mosaic' }
+		});
+
 		builder.addSchema('mosaicDescriptor', {
 			meta: { type: ModelType.object, schemaName: 'transactionMetadata' },
 			mosaic: { type: ModelType.object, schemaName: 'mosaicDescriptor.mosaic' }

--- a/catapult-sdk/test/plugins/mosaic_spec.js
+++ b/catapult-sdk/test/plugins/mosaic_spec.js
@@ -43,10 +43,11 @@ describe('mosaic plugin', () => {
 			const modelSchema = builder.build();
 
 			// Assert:
-			expect(Object.keys(modelSchema).length).to.equal(numDefaultKeys + 4);
+			expect(Object.keys(modelSchema).length).to.equal(numDefaultKeys + 5);
 			expect(modelSchema).to.contain.all.keys(
 				'mosaicDefinition',
 				'mosaicSupplyChange',
+				'ownedMosaics',
 				'mosaicDescriptor',
 				'mosaicDescriptor.mosaic'
 			);
@@ -58,6 +59,10 @@ describe('mosaic plugin', () => {
 			// - mosaic supply change
 			expect(Object.keys(modelSchema.mosaicSupplyChange).length).to.equal(Object.keys(modelSchema.transaction).length + 2);
 			expect(modelSchema.mosaicSupplyChange).to.contain.all.keys(['mosaicId', 'delta']);
+
+			// - owned mosaics
+			expect(Object.keys(modelSchema.ownedMosaics).length).to.equal(1);
+			expect(modelSchema.ownedMosaics).to.contain.all.keys(['mosaics']);
 
 			// - mosaic descriptor
 			expect(Object.keys(modelSchema.mosaicDescriptor).length).to.equal(2);

--- a/rest/src/plugins/mosaic/mosaicRoutes.js
+++ b/rest/src/plugins/mosaic/mosaicRoutes.js
@@ -37,13 +37,13 @@ module.exports = {
 			uint64.fromHex
 		);
 
-		const ownedMosaicsSender = routeUtils.createSender('mosaicDescriptor.mosaic');
+		const ownedMosaicsSender = routeUtils.createSender('ownedMosaics');
 
 		server.get('/account/:accountId/mosaics', (req, res, next) => {
 			const [type, accountId] = routeUtils.parseArgument(req.params, 'accountId', 'accountId');
 
 			return db.mosaicsByOwners(type, [accountId])
-				.then(ownedMosaicsSender.sendArray('accountId', res, next));
+				.then(mosaics => ownedMosaicsSender.sendOne('accountId', res, next)({ mosaics }));
 		});
 
 		server.post('/account/mosaics', (req, res, next) => {
@@ -56,7 +56,7 @@ module.exports = {
 
 			const accountIds = routeUtils.parseArgumentAsArray(req.params, idOptions.keyName, idOptions.parserName);
 			return db.mosaicsByOwners(idOptions.type, accountIds)
-				.then(ownedMosaicsSender.sendArray(idOptions.keyName, res, next));
+				.then(mosaics => ownedMosaicsSender.sendOne(idOptions.keyName, res, next)({ mosaics }));
 		});
 	}
 };

--- a/rest/test/plugins/mosaic/mosaicRoutes_spec.js
+++ b/rest/test/plugins/mosaic/mosaicRoutes_spec.js
@@ -99,8 +99,8 @@ describe('mosaic routes', () => {
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([address.stringToAddress(nonExistingTestAddress)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						payload: [],
-						type: 'mosaicDescriptor.mosaic'
+						payload: { mosaics: [] },
+						type: 'ownedMosaics'
 					});
 					expect(mockServer.next.calledOnce).to.equal(true);
 				});
@@ -119,8 +119,8 @@ describe('mosaic routes', () => {
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([convert.hexToUint8(nonExistingPublicKey)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						payload: [],
-						type: 'mosaicDescriptor.mosaic'
+						payload: { mosaics: [] },
+						type: 'ownedMosaics'
 					});
 					expect(mockServer.next.calledOnce).to.equal(true);
 				});
@@ -139,8 +139,8 @@ describe('mosaic routes', () => {
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([address.stringToAddress(testAddress)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						payload: [ownedMosaicsSample],
-						type: 'mosaicDescriptor.mosaic'
+						payload: { mosaics: [ownedMosaicsSample] },
+						type: 'ownedMosaics'
 					});
 					expect(mockServer.next.calledOnce).to.equal(true);
 				});
@@ -159,8 +159,8 @@ describe('mosaic routes', () => {
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([convert.hexToUint8(testPublicKey)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						payload: [ownedMosaicsSample],
-						type: 'mosaicDescriptor.mosaic'
+						payload: { mosaics: [ownedMosaicsSample] },
+						type: 'ownedMosaics'
 					});
 					expect(mockServer.next.calledOnce).to.equal(true);
 				});
@@ -190,8 +190,8 @@ describe('mosaic routes', () => {
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([address.stringToAddress(nonExistingTestAddress)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						payload: [],
-						type: 'mosaicDescriptor.mosaic'
+						payload: { mosaics: [] },
+						type: 'ownedMosaics'
 					});
 					expect(mockServer.next.calledOnce).to.equal(true);
 				});
@@ -210,8 +210,8 @@ describe('mosaic routes', () => {
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([convert.hexToUint8(nonExistingPublicKey)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						payload: [],
-						type: 'mosaicDescriptor.mosaic'
+						payload: { mosaics: [] },
+						type: 'ownedMosaics'
 					});
 					expect(mockServer.next.calledOnce).to.equal(true);
 				});
@@ -230,8 +230,8 @@ describe('mosaic routes', () => {
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([address.stringToAddress(testAddress)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						payload: [ownedMosaicsSample],
-						type: 'mosaicDescriptor.mosaic'
+						payload: { mosaics: [ownedMosaicsSample] },
+						type: 'ownedMosaics'
 					});
 					expect(mockServer.next.calledOnce).to.equal(true);
 				});
@@ -250,8 +250,8 @@ describe('mosaic routes', () => {
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([convert.hexToUint8(testPublicKey)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						payload: [ownedMosaicsSample],
-						type: 'mosaicDescriptor.mosaic'
+						payload: { mosaics: [ownedMosaicsSample] },
+						type: 'ownedMosaics'
 					});
 					expect(mockServer.next.calledOnce).to.equal(true);
 				});

--- a/rest/test/plugins/mosaic/mosaicRoutes_spec.js
+++ b/rest/test/plugins/mosaic/mosaicRoutes_spec.js
@@ -86,16 +86,17 @@ describe('mosaic routes', () => {
 		});
 
 		describe('GET', () => {
+			const route = mockServer.getRoute('/account/:accountId/mosaics').get();
+
 			it('returns empty if address not found', () => {
 				// Arrange:
 				const req = { params: { accountId: nonExistingTestAddress } };
-				const route = mockServer.getRoute('/account/:accountId/mosaics').get();
 
 				// Act:
 				return mockServer.callRoute(route, req).then(() => {
 					// Assert:
 					expect(dbMosaicsByOwnersFake.calledOnce).to.equal(true);
-					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.deep.equal(AccountType.address);
+					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.equal(AccountType.address);
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([address.stringToAddress(nonExistingTestAddress)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
@@ -109,13 +110,12 @@ describe('mosaic routes', () => {
 			it('returns empty if publicKey not found', () => {
 				// Arrange:
 				const req = { params: { accountId: nonExistingPublicKey } };
-				const route = mockServer.getRoute('/account/:accountId/mosaics').get();
 
 				// Act:
 				return mockServer.callRoute(route, req).then(() => {
 					// Assert:
 					expect(dbMosaicsByOwnersFake.calledOnce).to.equal(true);
-					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.deep.equal(AccountType.publicKey);
+					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.equal(AccountType.publicKey);
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([convert.hexToUint8(nonExistingPublicKey)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
@@ -129,13 +129,12 @@ describe('mosaic routes', () => {
 			it('returns owned mosaics by address', () => {
 				// Arrange:
 				const req = { params: { accountId: testAddress } };
-				const route = mockServer.getRoute('/account/:accountId/mosaics').get();
 
 				// Act:
 				return mockServer.callRoute(route, req).then(() => {
 					// Assert:
 					expect(dbMosaicsByOwnersFake.calledOnce).to.equal(true);
-					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.deep.equal(AccountType.address);
+					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.equal(AccountType.address);
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([address.stringToAddress(testAddress)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
@@ -149,13 +148,12 @@ describe('mosaic routes', () => {
 			it('returns owned mosaics by publicKey', () => {
 				// Arrange:
 				const req = { params: { accountId: testPublicKey } };
-				const route = mockServer.getRoute('/account/:accountId/mosaics').get();
 
 				// Act:
 				return mockServer.callRoute(route, req).then(() => {
 					// Assert:
 					expect(dbMosaicsByOwnersFake.calledOnce).to.equal(true);
-					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.deep.equal(AccountType.publicKey);
+					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.equal(AccountType.publicKey);
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([convert.hexToUint8(testPublicKey)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
@@ -169,7 +167,6 @@ describe('mosaic routes', () => {
 			it('throws error if accountId is invalid', () => {
 				// Arrange:
 				const req = { params: { accountId: 'AB12345' } };
-				const route = mockServer.getRoute('/account/:accountId/mosaics').get();
 
 				// Act + Assert:
 				expect(() => mockServer.callRoute(route, req)).to.throw('accountId has an invalid format');
@@ -177,16 +174,17 @@ describe('mosaic routes', () => {
 		});
 
 		describe('POST', () => {
+			const route = mockServer.getRoute('/account/mosaics').post();
+
 			it('returns empty if address not found', () => {
 				// Arrange:
 				const req = { params: { addresses: [nonExistingTestAddress] } };
-				const route = mockServer.getRoute('/account/mosaics').post();
 
 				// Act:
 				return mockServer.callRoute(route, req).then(() => {
 					// Assert:
 					expect(dbMosaicsByOwnersFake.calledOnce).to.equal(true);
-					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.deep.equal(AccountType.address);
+					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.equal(AccountType.address);
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([address.stringToAddress(nonExistingTestAddress)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
@@ -200,13 +198,12 @@ describe('mosaic routes', () => {
 			it('returns empty if publicKey not found', () => {
 				// Arrange:
 				const req = { params: { publicKeys: [nonExistingPublicKey] } };
-				const route = mockServer.getRoute('/account/mosaics').post();
 
 				// Act:
 				return mockServer.callRoute(route, req).then(() => {
 					// Assert:
 					expect(dbMosaicsByOwnersFake.calledOnce).to.equal(true);
-					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.deep.equal(AccountType.publicKey);
+					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.equal(AccountType.publicKey);
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([convert.hexToUint8(nonExistingPublicKey)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
@@ -220,13 +217,12 @@ describe('mosaic routes', () => {
 			it('returns owned mosaics by address', () => {
 				// Arrange:
 				const req = { params: { addresses: [testAddress] } };
-				const route = mockServer.getRoute('/account/mosaics').post();
 
 				// Act:
 				return mockServer.callRoute(route, req).then(() => {
 					// Assert:
 					expect(dbMosaicsByOwnersFake.calledOnce).to.equal(true);
-					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.deep.equal(AccountType.address);
+					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.equal(AccountType.address);
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([address.stringToAddress(testAddress)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
@@ -240,13 +236,12 @@ describe('mosaic routes', () => {
 			it('returns owned mosaics by publicKey', () => {
 				// Arrange:
 				const req = { params: { publicKeys: [testPublicKey] } };
-				const route = mockServer.getRoute('/account/mosaics').post();
 
 				// Act:
 				return mockServer.callRoute(route, req).then(() => {
 					// Assert:
 					expect(dbMosaicsByOwnersFake.calledOnce).to.equal(true);
-					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.deep.equal(AccountType.publicKey);
+					expect(dbMosaicsByOwnersFake.firstCall.args[0]).to.equal(AccountType.publicKey);
 					expect(dbMosaicsByOwnersFake.firstCall.args[1]).to.deep.equal([convert.hexToUint8(testPublicKey)]);
 
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
@@ -260,7 +255,6 @@ describe('mosaic routes', () => {
 			it('does not support publicKeys and addresses provided at the same time', () => {
 				// Arrange:
 				const req = { params: { addresses: [''], publicKeys: [''] } };
-				const route = mockServer.getRoute('/account/mosaics').post();
 
 				// Act + Assert:
 				expect(() => mockServer.callRoute(route, req)).to.throw('publicKeys and addresses cannot both be provided');
@@ -269,7 +263,6 @@ describe('mosaic routes', () => {
 			it('throws error if addresses contains an invalid address', () => {
 				// Arrange:
 				const req = { params: { addresses: [testAddress, 'AAAAAAAAAA'] } };
-				const route = mockServer.getRoute('/account/mosaics').post();
 
 				// Act + Assert:
 				expect(() => mockServer.callRoute(route, req)).to.throw('element in array addresses has an invalid format');
@@ -278,7 +271,6 @@ describe('mosaic routes', () => {
 			it('throws error if publicKeys contains an invalid publicKey', () => {
 				// Arrange:
 				const req = { params: { publicKeys: [testPublicKey, 'AAAAAAAAAA'] } };
-				const route = mockServer.getRoute('/account/mosaics').post();
 
 				// Act + Assert:
 				expect(() => mockServer.callRoute(route, req)).to.throw('element in array publicKeys has an invalid format');


### PR DESCRIPTION
Fixes #187 

Old output:

```
 [
     {
         "id": "0DC67FBE1CAD29E3",
         ...
         "duration": "0"
     },
     {
         "id": "26514E2A1EF33824",
        ...
         "duration": "0"
     }
 ]
```

New output:

```
{
    "mosaics": [
        {
            "id": "0DC67FBE1CAD29E3",
            ...
            "duration": "0"
        },
        {
            "id": "26514E2A1EF33824",
           ...
            "duration": "0"
        }
    ]
}
```