### PR TITLE
Task/233 remove page size step

### DIFF
--- a/catapult-sdk/package.json
+++ b/catapult-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catapult-sdk",
-  "version": "0.7.20.5",
+  "version": "0.7.20.6",
   "description": "Catapult SDK core",
   "main": "_build/index.js",
   "scripts": {

--- a/rest/package.json
+++ b/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catapult-api-rest",
-  "version": "1.0.20.5",
+  "version": "1.0.20.6",
   "description": "",
   "main": "_build/index.js",
   "scripts": {

--- a/rest/resources/rest.json
+++ b/rest/resources/rest.json
@@ -29,7 +29,6 @@
     "name": "catapult",
     "pageSizeMin": 10,
     "pageSizeMax": 100,
-    "pageSizeStep": 25,
     "maxConnectionAttempts": 5,
     "baseRetryDelay": 500
   },

--- a/rest/src/index.js
+++ b/rest/src/index.js
@@ -125,8 +125,7 @@ const registerRoutes = (server, db, services) => {
 			network: services.config.network,
 			pageSize: {
 				min: services.config.db.pageSizeMin,
-				max: services.config.db.pageSizeMax,
-				step: services.config.db.pageSizeStep
+				max: services.config.db.pageSizeMax
 			},
 			apiNode: services.config.apiNode,
 			websocket: services.config.websocket

--- a/rest/src/routes/blockRoutes.js
+++ b/rest/src/routes/blockRoutes.js
@@ -70,9 +70,12 @@ module.exports = {
 		});
 
 		server.get('/blocks/:height/limit/:limit', (req, res, next) => {
-			const height = parseHeight(req.params);
+			const height = parseHeight(req.params) || 1;
 			const limit = routeUtils.parseArgument(req.params, 'limit', 'uint');
 			const sanitizedLimit = getSanitizedLimit(services.config.pageSize, limit);
+
+			if (sanitizedLimit !== limit)
+				return res.redirect(`/blocks/${height}/limit/${sanitizedLimit}`, next); // redirect calls next
 
 			return db.blocksFrom(height, sanitizedLimit).then(blocks => {
 				res.send({ payload: blocks, type: routeResultTypes.block });

--- a/rest/src/routes/blockRoutes.js
+++ b/rest/src/routes/blockRoutes.js
@@ -32,12 +32,11 @@ const { BinaryParser } = catapult.parser;
 
 const parseHeight = params => routeUtils.parseArgument(params, 'height', 'uint');
 
-const getLimit = (validLimits, params) => {
-	const limit = routeUtils.parseArgument(params, 'limit', 'uint');
-	return -1 === validLimits.indexOf(limit) ? undefined : limit;
+const getSanitizedLimit = (pageSize, limit) => {
+	let sanitizedLimit = Math.max(limit, pageSize.min);
+	sanitizedLimit = Math.min(sanitizedLimit, pageSize.max);
+	return sanitizedLimit;
 };
-
-const alignDown = (height, alignment) => (Math.floor((height - 1) / alignment) * alignment) + 1;
 
 module.exports = {
 	register: (server, db, services) => {
@@ -71,17 +70,11 @@ module.exports = {
 		});
 
 		server.get('/blocks/:height/limit/:limit', (req, res, next) => {
-			const validPageSizes = routeUtils.generateValidPageSizes(services.config.pageSize);
-
 			const height = parseHeight(req.params);
-			const limit = getLimit(validPageSizes, req.params);
+			const limit = routeUtils.parseArgument(req.params, 'limit', 'uint');
+			const sanitizedLimit = getSanitizedLimit(services.config.pageSize, limit);
 
-			const sanitizedLimit = limit || validPageSizes[0];
-			const sanitizedHeight = alignDown(height || 1, sanitizedLimit);
-			if (sanitizedHeight !== height || !limit)
-				return res.redirect(`/blocks/${sanitizedHeight}/limit/${sanitizedLimit}`, next); // redirect calls next
-
-			return db.blocksFrom(height, limit).then(blocks => {
+			return db.blocksFrom(height, sanitizedLimit).then(blocks => {
 				res.send({ payload: blocks, type: routeResultTypes.block });
 				next();
 			});

--- a/rest/src/routes/routeUtils.js
+++ b/rest/src/routes/routeUtils.js
@@ -144,23 +144,6 @@ const routeUtils = {
 	},
 
 	/**
-	 * Generates valid page sizes from page size config.
-	 * @param {object} config Page size config.
-	 * @returns {object} Valid limits.
-	 */
-	generateValidPageSizes: config => {
-		const pageSizes = [];
-		const start = config.min + (0 === config.min % config.step ? 0 : config.step - (config.min % config.step));
-		for (let pageSize = start; config.max >= pageSize; pageSize += config.step)
-			pageSizes.push(pageSize);
-
-		if (0 === pageSizes.length)
-			throw Error('page size configuration does not specify any valid page sizes');
-
-		return pageSizes;
-	},
-
-	/**
 	 * Creates a sender for forwarding one or more objects of a given type.
 	 * @param {module:routes/routeResultTypes} type Object type.
 	 * @returns {object} Sender.

--- a/rest/test/routes/allRoutes_spec.js
+++ b/rest/test/routes/allRoutes_spec.js
@@ -24,7 +24,7 @@ const allRoutes = require('../../src/routes/allRoutes');
 describe('all routes', () => {
 	const registerAll = server => {
 		const config = {
-			pageSize: { min: 10, max: 100, step: 25 },
+			pageSize: { min: 10, max: 100 },
 			transactionStates: [],
 			apiNode: { timeout: 1000 }
 		};

--- a/rest/test/routes/routeUtils_spec.js
+++ b/rest/test/routes/routeUtils_spec.js
@@ -237,62 +237,6 @@ describe('route utils', () => {
 		});
 	});
 
-	describe('generate valid page sizes', () => {
-		it('can generate page sizes inclusive of min and max', () => {
-			// Act:
-			const pageSizes = routeUtils.generateValidPageSizes({ min: 30, max: 100, step: 10 });
-
-			// Assert:
-			expect(pageSizes).to.deep.equal([30, 40, 50, 60, 70, 80, 90, 100]);
-		});
-
-		it('can generate page sizes inclusive of min but not max', () => {
-			// Act:
-			const pageSizes = routeUtils.generateValidPageSizes({ min: 30, max: 99, step: 10 });
-
-			// Assert:
-			expect(pageSizes).to.deep.equal([30, 40, 50, 60, 70, 80, 90]);
-		});
-
-		it('can generate page sizes inclusive of max but not min', () => {
-			// Act:
-			const pageSizes = routeUtils.generateValidPageSizes({ min: 31, max: 100, step: 25 });
-
-			// Assert:
-			expect(pageSizes).to.deep.equal([50, 75, 100]);
-		});
-
-		it('can generate page sizes exclusive of min and max', () => {
-			// Act:
-			const pageSizes = routeUtils.generateValidPageSizes({ min: 10, max: 110, step: 25 });
-
-			// Assert:
-			expect(pageSizes).to.deep.equal([25, 50, 75, 100]);
-		});
-
-		it('can generate page sizes when only a single valid page size is configured', () => {
-			// Act:
-			const pageSizes = routeUtils.generateValidPageSizes({ min: 30, max: 45, step: 40 });
-
-			// Assert:
-			expect(pageSizes).to.deep.equal([40]);
-		});
-
-		it('cannot generate page sizes when there are no valid page sizes configured ', () => {
-			// Arrange:
-			const testCases = [
-				{ config: { min: 30, max: 45, step: 25 }, desc: 'no step multiple is within range' },
-				{ config: { min: 30, max: 45, step: 50 }, desc: 'step is greater than max' }
-			];
-
-			// Act:
-			const errorMessage = 'page size configuration does not specify any valid page sizes';
-			testCases.forEach(testCase => {
-				expect(() => routeUtils.generateValidPageSizes(testCase.config), testCase.name).to.throw(errorMessage);
-			});
-		});
-	});
-
 	describe('sender', () => {
 		const sendTest = (sender, assertResponse) => {
 			// Arrange: set up the route params


### PR DESCRIPTION
Fixes #233 

Notice the endpoint behavior has slightly changed. Here https://nemtech.github.io/nem2-openapi/#operation/getBlocksByHeightWithLimit it says:

`Block height. If height -1 is not a multiple of the limit provided, the inferior closest multiple + 1 is used instead.`

This used to make sense when limit was rounded to page size with step parameter. Now that we allow any page size this rounding doesn't make sense anymore. So height is not altered in anyway. Except for height 0 when it is changed to 1.

Limit is still sanitized to be in range of page size min and max.