### PR TITLE
Task/t186 fix duplicate connections

### DIFF
--- a/catapult-sdk/package.json
+++ b/catapult-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catapult-sdk",
-  "version": "0.7.20.7",
+  "version": "0.7.20.8",
   "description": "Catapult SDK core",
   "main": "_build/index.js",
   "config": {

--- a/rest/package.json
+++ b/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catapult-api-rest",
-  "version": "1.0.20.7",
+  "version": "1.0.20.8",
   "description": "",
   "main": "_build/index.js",
   "scripts": {

--- a/rest/src/connection/connectionService.js
+++ b/rest/src/connection/connectionService.js
@@ -77,12 +77,16 @@ module.exports.createConnectionService = (config, connectionFactory, authPromise
 					delete authenticatingConnectionPromises[node];
 				}
 
+				// return and additionally, return the connection for possible queued connections on `authenticatingConnectionPromises`
 				resolve(serverConnection);
-			}, reject)
-			.catch(err => {
+				return serverConnection;
+			}).catch(err => {
 				if (isPersistent)
 					delete authenticatingConnectionPromises[node];
+
+				// reject and additionally, return the connection for possible queued connections on `authenticatingConnectionPromises`
 				reject(err);
+				throw err;
 			});
 
 		if (isPersistent)

--- a/rest/test/connection/connectionService_spec.js
+++ b/rest/test/connection/connectionService_spec.js
@@ -261,4 +261,70 @@ describe('connection service', () => {
 			});
 		}
 	);
+
+	describe('handles first simultaneous connections correctly when authentication is delayed', () => {
+		it('on successful authentication both parties should lease the same connection', () => {
+			// Arrange:
+			const context = createTestContext();
+			let authPromiseResolve;
+			const connectionService = createConnectionService(
+				Test_Config,
+				context.mockConnectionFactory,
+				context.createAuthPromise(() => new Promise(resolve => {
+					authPromiseResolve = resolve;
+				}))
+			);
+
+			// Act:
+			let firstConn;
+			let secondConn;
+			const leasePromises = Promise.all([
+				connectionService.lease().then(firstConnection => {
+					// Assert:
+					firstConn = firstConnection;
+					expect(context.numConnectionFactoryCalls).to.equal(1);
+				}),
+				connectionService.lease().then(secondConnection => {
+					// Assert:
+					secondConn = secondConnection;
+					expect(context.numConnectionFactoryCalls).to.equal(1);
+				})
+			]).then(() => {
+				// Assert:
+				expect(secondConn).to.equal(firstConn);
+			});
+
+			// unblocks the first promise (simulates delayed acceptance of authentication)
+			authPromiseResolve();
+
+			return leasePromises;
+		});
+
+		it('on failed authentication both parties should fail on the same pending authentication promise', done => {
+			// Arrange:
+			const context = createTestContext();
+			let authPromiseReject;
+			const connectionService = createConnectionService(
+				Test_Config,
+				context.mockConnectionFactory,
+				context.createAuthPromise(() => new Promise((resolve, reject) => {
+					authPromiseReject = reject;
+				}))
+			);
+			const authError = Error('failure auth promise');
+
+			// Act:
+			Promise.all([
+				connectionService.lease(),
+				connectionService.lease()
+			]).catch(err => {
+				// Assert:
+				expect(err).to.equal(authError);
+				done();
+			});
+
+			// unblocks the first promise (simulates delayed authentication failure)
+			authPromiseReject(authError);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #186 (#6), and hopefully the random `Address already in use` failure from tests, though it's just a wild guess

basically added a cached "pending for authentication" object to store connections that have not been authenticated yet since this does not happen until `lease()`, in this window of time if multiple requests are received different connections are spawned with conflicting addresses
