### PR TITLE
Updated versioning

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,7 +4,7 @@ in-between the listed versions_
 
 | catapult-rest | catapult-server | Notes                                                              |
 |---------------|-----------------|--------------------------------------------------------------------|
-| v1.1.0.0      | v9.6.1          | Address resized (25 -> 24 bytes)<br>Updated REST version numbering |
+| v1.1.0        | v9.6.1          | Address resized (25 -> 24 bytes)<br>Updated REST version numbering |
 | v1.0.20.50    | v9.5.1          | VRF support                                                        |
 | v1.0.20.31    | v9.4.1          | TLS support                                                        |
 | v1.0.20.24    | v9.3.1          | -                                                                  |

--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ Catapult REST gateway combines HTTP and WebSockets to perform read and write act
 
 Make sure you choose a [version compatible](COMPATIBILITY.md) with the [catapult-server][catapult-server] node you want to use it with.
 
-Version number is described as follows:
+Starting on `v1.1.0`, version numbers are described as follows:
 
-`v1.X.Y.Z`
+`vX.Y.Z`
 
-- The first numer is symbolic for pre-release and should not be taken into consideration.
 - X: This serves to lock for compatibility with `catapult-server`, thus it is safe to update by keeping this number without REST
 losing server compatibility. Additionally, any breaking change to the server should require to upgrade this number.
 - Y: This serves to lock on safe updates to this project, thus it is safe to update by keeping this number without worrying about

--- a/catapult-sdk/package.json
+++ b/catapult-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catapult-sdk",
-  "version": "0.7.20.52",
+  "version": "1.1.0",
   "description": "Catapult SDK core",
   "main": "_build/index.js",
   "scripts": {

--- a/rest/package.json
+++ b/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catapult-api-rest",
-  "version": "1.0.20.52",
+  "version": "1.1.0",
   "description": "",
   "main": "_build/index.js",
   "scripts": {


### PR DESCRIPTION
had issues with npm and 4 digits, so dropping the first useless digit