### PR TITLE
Docker deployments using Travis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+Dockerfile
+.dockerignore
+docker.sh
+
+.idea
+.vscode
+.git
+.gitignore
+.travis.yml
+
+*/node_modules
+*/_build
+
+**/npm-*.log
+**/yarn-*.log
+**/catapult-*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 
 node_js:
   - "12"
-
+services:
+  - docker
 addons:
   apt:
     sources:
@@ -29,4 +30,17 @@ before_script:
 - sudo systemctl start mongod
 - sh yarn_setup.sh
 
-script: cd ${SUBPROJECT} && yarn run lint && yarn run test:travis
+script: cd ${SUBPROJECT} && yarn run lint && yarn run test:travis && cd ..
+
+jobs:
+  include:
+    - stage: docker alpha deploy
+      env:
+        - SUBPROJECT=rest
+      script: /bin/sh docker.sh
+      if: branch = master
+    - stage: docker release deploy
+      env:
+        - SUBPROJECT=rest
+      script: /bin/sh docker.sh --release
+      if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       env:
         - SUBPROJECT=rest
       script: /bin/sh docker.sh
-      if: branch = master
+      if: branch = master AND type != pull_request
     - stage: docker release deploy
       env:
         - SUBPROJECT=rest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:12.18.1-alpine
+RUN apk add --update\
+ python \
+ python3 \
+ build-base \
+ zeromq-dev \
+ && rm -rf /var/cache/apk/*
+WORKDIR /app
+COPY . /app/catapult-rest
+RUN cd catapult-rest \
+ && ./yarn_setup.sh
+RUN cd catapult-rest/rest \
+ && yarn build
+WORKDIR /app/catapult-rest/rest

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+if [ "${DOCKER_IMAGE_NAME}" = "" ]
+then
+  echo "Docker deployment ignored env DOCKER_IMAGE_NAME has not been provided"
+  exit;
+fi
+
+if [ ! "${DOCKER_PASSWORD}" = "" ]
+then
+  echo "Login into docker..."
+  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+fi
+
+cd rest
+CURRENT_VERSION=$(npm run version --silent)
+cd ..
+
+if [ "$1" = "--release" ]
+then
+   VERSION="${CURRENT_VERSION}"
+else
+   VERSION="${CURRENT_VERSION}-alpha"
+fi
+
+echo "Creating image ${DOCKER_IMAGE_NAME}:${VERSION}"
+docker build -t "${DOCKER_IMAGE_NAME}:${VERSION}" .
+docker images
+
+# Quick test, the expected error is ENOENT: no such file or directory, open '../resources/rest.json'
+echo "Testing image ${DOCKER_IMAGE_NAME}:${VERSION}. NOTE: ENOENT: no such file or directory, open '../resources/rest.json is expected"
+docker run --rm "${DOCKER_IMAGE_NAME}:${VERSION}" npm start
+
+echo "Pushing image ${DOCKER_IMAGE_NAME}:${VERSION}"
+docker push "${DOCKER_IMAGE_NAME}:${VERSION}"

--- a/docker.sh
+++ b/docker.sh
@@ -2,15 +2,24 @@
 
 if [ "${DOCKER_IMAGE_NAME}" = "" ]
 then
-  echo "Docker deployment ignored env DOCKER_IMAGE_NAME has not been provided"
-  exit;
+  echo "Docker deployment error. Env DOCKER_IMAGE_NAME has not been provided"
+  exit 128
 fi
 
-if [ ! "${DOCKER_PASSWORD}" = "" ]
+if [ "${DOCKER_USERNAME}" = "" ]
 then
-  echo "Login into docker..."
-  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  echo "Docker deployment error. Env DOCKER_USERNAME has not been provided"
+  exit 128
 fi
+
+if [ "${DOCKER_PASSWORD}" = "" ]
+then
+  echo "Docker deployment error. Env DOCKER_PASSWORD has not been provided"
+  exit 128
+fi
+
+echo "Login into docker..."
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 cd rest
 CURRENT_VERSION=$(npm run version --silent)

--- a/rest/package.json
+++ b/rest/package.json
@@ -7,6 +7,7 @@
     "clean": "rimraf _build && mkdir _build",
     "build": "ncp src/ _build",
     "rebuild": "npm run clean && npm run build",
+    "version": "echo $npm_package_version",
     "start": "node _build/index.js",
     "start:debug": "node src/index.js",
     "test": "mocha --full-trace --recursive",


### PR DESCRIPTION
Hi guys

In order to improve the CI experience, I've upgraded Travis to deploy docker images in this PR. 

Each `master` build will build and push docker image with a name like `symbolplatform/symbol-rest:1.2.0-alpha` into the docker hub. The idea is that we can automatically pull the newly created image down the line into Bootstrap (local) or a possible  DevNet (aws). Using rest alpha will speed up parallel development, SDKs and clients can test your just finish feature and provide feedback before an official release

Once you are happy with your development, you can `tag` master, then Travis will pick up the version, build and deploy into docker hub from that tag. The deployed image will be `symbolplatform/symbol-rest:1.2.0`. This image can be then be picked by TestNet (aws) or Bootstrap (local) when doing a suite-wide release. 

The image create is based on the current TestNet [DockerFile](https://github.com/Wayonb/symbol-testnet-bootstrap/blob/master/common/dockerfiles/symbol-rest/Dockerfile). The only difference is that it doesn't need to clone the repo,  just copy the Travis working dir with the current master or tagged code. 

Before merging this PR, you need to provide the following ENV in [Travis's settings ](https://travis-ci.com/github/nemtech/catapult-rest/settings)

- DOCKER_IMAGE_NAME. example: `symbolplatform/symbol-rest`
- DOCKER_USERNAME. The docker user with permission to push into the docker orga (symbolplatform)
- DOCKER_PASSWORD. The docker user's password with permission to push into the docker orga (symbolplatform)

@dgarcia360 , what would it be the best NGL orga in dockerhub? Would we keep `symbolplatform`? Let us know when you have the NGL's bot docker info and credentials.

I've tested the process in my fork and it works fine (master and tag build).

![Selection_151](https://user-images.githubusercontent.com/5390558/87893149-61134c00-ca15-11ea-9eb3-a4de13fbf4ad.png)

The process adds 4 minutes to the master build. Branch or PR builds won't run the last deploy, it doesn't slow down the PR review process.

We can speed up Travis (if needed):
- I don't think `node_modules` folders are being cached in Travis as they are in subfolders. The dependencies are downloaded and compiled each `test` build (this is a current issue)
- Set up Travis to cache docker images and checkpoints (current one is `node:12.18.1-alpine`). This is not out of the box but there are some solutions [posted](https://github.com/travis-ci/travis-ci/issues/5358). 
- Copy `node_modules` from Travis working dir to the docker images when creating (by removing */node_modules from. dockerignore). For this, we need to change the parent image from `node:12.18.1-alpine` to `12.18.2-stretch` or an image compatible with Travis so the already compiled and downloaded `node_modules` folders work on the image by just copying them. This will speed up release but increase the image size from 743MB to 1.14GB (alpine images are smaller). Also `ash` is replaced by `bash` when running the image (bash is used catapult-server and catapult-tools). @Wayonb what do you think? 


NOTES:
- This process is slightly different from other release processes like the SDKs, CLI, open API, etc. There is no release branch that automatically upgrades the version, pushes artifacts, and tags the repo. In this case, you need to manually tag and then upgrade the version in the rest's package.json. I didn't want to change your release process, I just added an automatic deploy step. If you like the other `release` branch process we can upgrade it in future PR.