### PR TITLE
Node Public Key exposed in /node/info

### DIFF
--- a/catapult-sdk/src/model/ModelSchemaBuilder.js
+++ b/catapult-sdk/src/model/ModelSchemaBuilder.js
@@ -228,7 +228,8 @@ class ModelSchemaBuilder {
 				friendlyName: ModelType.string,
 				host: ModelType.string,
 				publicKey: ModelType.binary,
-				networkGenerationHashSeed: ModelType.binary
+				networkGenerationHashSeed: ModelType.binary,
+				nodePublicKey: ModelType.binary
 			},
 			communicationTimestamps: {
 				receiveTimestamp: ModelType.uint64,

--- a/catapult-sdk/test/model/ModelSchemaBuilder_spec.js
+++ b/catapult-sdk/test/model/ModelSchemaBuilder_spec.js
@@ -250,6 +250,7 @@ describe('model schema builder', () => {
 
 				'nodeInfo.publicKey',
 				'nodeInfo.networkGenerationHashSeed',
+				'nodeInfo.nodePublicKey',
 				'stateTree.tree.schemaName'
 			]);
 		});

--- a/rest/package.json
+++ b/rest/package.json
@@ -46,7 +46,7 @@
     "nodemon": "^2.0.6",
     "rimraf": "^2.6.3",
     "sinon": "^7.3.2",
-    "symbol-bootstrap": "0.2.1"
+    "symbol-bootstrap": "^0.2.2-alpha-202011112255"
   },
   "dependencies": {
     "catapult-sdk": "link:../catapult-sdk",
@@ -58,6 +58,7 @@
     "restify-errors": "^8.0.0",
     "winston": "^3.2.1",
     "ws": "^7.1.0",
-    "zeromq": "^5.1.0"
+    "zeromq": "^5.1.0",
+    "sshpk": "1.16.1"
   }
 }

--- a/rest/src/connection/connectionService.js
+++ b/rest/src/connection/connectionService.js
@@ -48,9 +48,9 @@ module.exports.createConnectionService = (config, logger = () => {}) => {
 
 		const contextOptions = {
 			minVersion: 'TLSv1.3',
-			key: config.key,
-			cert: config.certificate,
-			ca: config.caCertificate
+			key: node.key,
+			cert: node.certificate,
+			ca: node.caCertificate
 			// sigalgs: 'ed25519'
 		};
 		let secureContext;

--- a/rest/src/routes/nodeRoutes.js
+++ b/rest/src/routes/nodeRoutes.js
@@ -116,8 +116,10 @@ module.exports = {
 				.singleUse()
 				.then(connection => connection.pushPull(packetBuffer, timeout))
 				.then(packet => {
+					const response = buildResponse(packet, nodeInfoCodec, routeResultTypes.nodeInfo);
+					response.payload.nodePublicKey = services.config.apiNode.nodePublicKey;
 					res.send(
-						buildResponse(packet, nodeInfoCodec, routeResultTypes.nodeInfo)
+						response
 					);
 					next();
 				});

--- a/rest/test/routes/nodeRoutes_spec.js
+++ b/rest/test/routes/nodeRoutes_spec.js
@@ -214,6 +214,11 @@ describe('node routes', () => {
 					0xB4, 0x64, 0x72, 0x42, 0xF1, 0xFF, 0x11, 0x00, 0x9F, 0xD0, 0x9A, 0x8F, 0x3D, 0x35, 0x87, 0xF8
 				]);
 
+				const nodePublicKeyBuffer = Buffer.from([
+					0xE4, 0x28, 0xC1, 0xF1, 0xC9, 0x97, 0x5C, 0x3A, 0xA5, 0x1B, 0x2A, 0x41, 0x76, 0x81, 0x58, 0xC1,
+					0x07, 0x7D, 0x16, 0xB4, 0x60, 0x99, 0x9A, 0xAB, 0xE7, 0xAD, 0xB5, 0x26, 0x2B, 0xE2, 0x9A, 0x68
+				]);
+
 				const packet = {
 					type: 601,
 					size: 57,
@@ -230,6 +235,7 @@ describe('node routes', () => {
 					])
 				};
 				const services = serviceCreator(packet);
+				services.config.apiNode.nodePublicKey = nodePublicKeyBuffer;
 
 				// Act:
 				return test.route.prepareExecuteRoute(nodeRoutes.register, '/node/info', 'get', {}, {}, services, routeContext =>
@@ -247,6 +253,7 @@ describe('node routes', () => {
 								port: 7900,
 								publicKey: publicKeyBuffer,
 								networkGenerationHashSeed: networkGenerationHashSeedBuffer,
+								nodePublicKey: nodePublicKeyBuffer,
 								roles: 2,
 								version: 23
 							},


### PR DESCRIPTION
This PR is an alternative to https://github.com/nemtech/catapult-rest/pull/525

Instead of creating a new endpoint, the node public key is added to the node info. 

![image](https://user-images.githubusercontent.com/5390558/99137026-0080ce00-2607-11eb-971e-32f58f39b8b5.png)

ideally, this PR is temporary until server api provides the node public keys for local and known remote peers.

https://github.com/nemtech/catapult-server/issues/110

If core could return that, node/info and node/peers (for the remote known peers) would work out of the box without rest loading the key from the pem file. Clients would know th node keys of all the known peers via one rest. 