### PR TITLE
Allowing address aliases in web socket subscriptions

### DIFF
--- a/catapult-sdk/src/model/namespace.js
+++ b/catapult-sdk/src/model/namespace.js
@@ -19,6 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+const convert = require('../utils/convert');
 /**
  * Catapult model namespace.
  * @enum {numeric}
@@ -32,6 +33,20 @@ const namespace = {
 
 		/** Address alias. */
 		address: 2
+	},
+	/**
+	 * Format a namespaceId *alias* into a valid recipient field value.
+	 * @param {Uint8Array} namespaceId The namespaceId
+	 * @param {number} networkIdentifier network identifier serialized in the output.
+	 * @returns {Uint8Array} The padded notation of the alias
+	 */
+	encodeNamespace(namespaceId, networkIdentifier) {
+		// 0x91 | namespaceId on 8 bytes | 15 bytes 0-pad = 24 bytes
+		const padded = new Uint8Array(1 + 8 + 15);
+		padded.set([networkIdentifier | 0x01], 0);
+		padded.set(namespaceId.reverse(), 1);
+		padded.set(convert.hexToUint8('00'.repeat(15)), 9);
+		return padded;
 	}
 };
 

--- a/catapult-sdk/test/model/namespace_spec.js
+++ b/catapult-sdk/test/model/namespace_spec.js
@@ -20,6 +20,7 @@
  */
 
 const namespace = require('../../src/model/namespace');
+const convert = require('../../src/utils/convert');
 const { expect } = require('chai');
 
 describe('namespace', () => {
@@ -41,6 +42,17 @@ describe('namespace', () => {
 
 			// Assert:
 			expect(Object.keys(namespace.aliasType).length).to.equal(Object.keys(reverseMapping).length);
+		});
+	});
+
+	describe('encodeNamespace', () => {
+		it('Testnet valid', () => {
+			// Assert:
+			const encoded = namespace.encodeNamespace(convert.hexToUint8('C0FB8AA409916260'), 152);
+			const encodedHex = convert.uint8ToHex(encoded);
+			const expectedEncodedHex = '9960629109A48AFBC0000000000000000000000000000000';
+			expect(encodedHex).to.be.equal(expectedEncodedHex);
+			expect(encoded).to.be.deep.equal(convert.hexToUint8(expectedEncodedHex));
 		});
 	});
 });

--- a/rest/src/plugins/routeSystem.js
+++ b/rest/src/plugins/routeSystem.js
@@ -30,6 +30,7 @@ const namespace = require('./namespace/namespace');
 const receipts = require('./receipts/receipts');
 const restrictions = require('./restrictions/restrictions');
 const MessageChannelBuilder = require('../connection/MessageChannelBuilder');
+const catapult = require('catapult-sdk');
 
 const plugins = {
 	accountLink: empty,
@@ -62,7 +63,8 @@ module.exports = {
 	 */
 	configure: (pluginNames, server, db, services) => {
 		const transactionStates = [];
-		const messageChannelBuilder = new MessageChannelBuilder(services.config.websocket);
+		const networkIdentifier = catapult.model.networkInfo.networks[services.config.network.name].id;
+		const messageChannelBuilder = new MessageChannelBuilder(services.config.websocket, networkIdentifier);
 		(pluginNames || []).forEach(pluginName => {
 			if (!plugins[pluginName])
 				throw Error(`plugin '${pluginName}' not supported by route system`);

--- a/rest/test/plugins/routeSystem_spec.js
+++ b/rest/test/plugins/routeSystem_spec.js
@@ -24,7 +24,7 @@ const { test } = require('../routes/utils/routeTestUtils');
 const { expect } = require('chai');
 
 describe('route system', () => {
-	const servicesTemplate = { config: { websocket: {} }, connections: {} };
+	const servicesTemplate = { config: { websocket: {}, network: { name: 'publicTest' } }, connections: {} };
 	const configureTrailingParameters = [{ put: () => {} }, {}, servicesTemplate];
 
 	it('cannot register unknown extension', () => {
@@ -157,7 +157,7 @@ describe('route system', () => {
 
 		it('extension filter accepts marker without topic param with allowOptionalAddress', () => {
 			// Arrange:
-			const services = { config: { websocket: { allowOptionalAddress: true } }, connections: {} };
+			const services = { config: { websocket: { allowOptionalAddress: true }, network: { name: 'publicTest' } }, connections: {} };
 			const { messageChannelDescriptors } = routeSystem.configure(['aggregate'], { put: () => {} }, {}, services);
 			const { filter } = messageChannelDescriptors.partialAdded;
 


### PR DESCRIPTION
Examples:

/status/C0FB8AA409916260
/status/TAHNZXQBC57AA7KJTMGS3PJPZBXN7DV5JHJU42A
/confirmedAdded/C0FB8AA409916260
/confirmedAdded/TAHNZXQBC57AA7KJTMGS3PJPZBXN7DV5JHJU42A

Fixes https://github.com/nemtech/catapult-rest/issues/537
SDKs to be updated. They can now send alias namespace hex when subscribing as-is instead of resolving the addres.