### PR TITLE
Estimated counts in node/storage

### DIFF
--- a/rest/src/db/CatapultDb.js
+++ b/rest/src/db/CatapultDb.js
@@ -166,9 +166,9 @@ class CatapultDb {
 	 * @returns {Promise} Promise that resolves to the sizes of collections in the database.
 	 */
 	storageInfo() {
-		const blockCountPromise = this.database.collection('blocks').countDocuments();
-		const transactionCountPromise = this.database.collection('transactions').countDocuments();
-		const accountCountPromise = this.database.collection('accounts').countDocuments();
+		const blockCountPromise = this.database.collection('blocks').estimatedDocumentCount();
+		const transactionCountPromise = this.database.collection('transactions').estimatedDocumentCount();
+		const accountCountPromise = this.database.collection('accounts').estimatedDocumentCount();
 		return Promise.all([blockCountPromise, transactionCountPromise, accountCountPromise])
 			.then(storageInfo => ({ numBlocks: storageInfo[0], numTransactions: storageInfo[1], numAccounts: storageInfo[2] }));
 	}


### PR DESCRIPTION
Fixes https://github.com/nemtech/catapult-rest/issues/555

Should we estimate all these collections or just a few like transactions? I don't think /node/storage is used for accurate calculations but mainly just for general information in the wallet. 

The main issue of estimated counts could be the unclean shutdown. 

https://docs.mongodb.com/manual/reference/method/db.collection.estimatedDocumentCount/index.html#unclean-shutdown

@Jaguar0625 , do you know if the recovery process calls mongo's validate?

https://docs.mongodb.com/manual/reference/command/validate/#dbcmd.validate