### PR TITLE
Excluding duplicated names from result

### DIFF
--- a/rest/src/plugins/namespace/namespaceUtils.js
+++ b/rest/src/plugins/namespace/namespaceUtils.js
@@ -85,7 +85,8 @@ const namespaceUtils = {
 								aliasName += `.${uniqueTransactions.find(t => t.namespaceId.equals(n.namespace.level1)).name}`;
 							if (3 <= n.namespace.depth)
 								aliasName += `.${uniqueTransactions.find(t => t.namespaceId.equals(n.namespace.level2)).name}`;
-							names.push(aliasName);
+							if (-1 === names.indexOf(aliasName))
+								names.push(aliasName);
 						});
 					return { [aliasFieldName]: id, names };
 				});

--- a/rest/test/plugins/namespace/namespaceUtils_spec.js
+++ b/rest/test/plugins/namespace/namespaceUtils_spec.js
@@ -61,6 +61,8 @@ describe('namespace utils', () => {
 		const registerNamespaceTransactionsFromNamespaceIdsFake = sinon.fake(() => {
 			const transactions = [
 				createRegisterNamespaceTransaction(12345, 1, 1, 'a'),
+				createRegisterNamespaceTransaction(33437, 1, 1, 'a'),
+				createRegisterNamespaceTransaction(12345, 1, 1, 'a'),
 				createRegisterNamespaceTransaction(67891, 1, 1, 'b'),
 				createRegisterNamespaceTransaction(38467, 1, 1, 'c'),
 				createRegisterNamespaceTransaction(23456, 1, 1, 'd'),


### PR DESCRIPTION
This is an extra check removing duplicated names. I haven't been able to reproduce the original bug nor find an example of this bug in testnet. 

Fixes https://github.com/nemtech/catapult-rest/issues/530