### PR TITLE
Optimise zmq socket connection

### DIFF
--- a/rest/src/connection/MessageChannelBuilder.js
+++ b/rest/src/connection/MessageChannelBuilder.js
@@ -73,11 +73,11 @@ class MessageChannelBuilder {
 		// add basic descriptors
 		this.descriptors.block = createBlockDescriptor(
 			Buffer.of(0x49, 0x6A, 0xCA, 0x80, 0xE4, 0xD8, 0xF2, 0x9F),
-			ServerMessageHandler.block
+			ServerMessageHandler.zmqMessageHandler
 		);
 		this.descriptors.finalizedBlock = createBlockDescriptor(
 			Buffer.of(0x54, 0x79, 0xCE, 0x31, 0xA0, 0x32, 0x48, 0x4D),
-			ServerMessageHandler.finalizedBlock
+			ServerMessageHandler.zmqMessageHandler
 		);
 		this.add('confirmedAdded', 'a', ServerMessageHandler.zmqMessageHandler);
 		this.add('unconfirmedAdded', 'u', ServerMessageHandler.zmqMessageHandler);

--- a/rest/src/connection/MessageChannelBuilder.js
+++ b/rest/src/connection/MessageChannelBuilder.js
@@ -79,12 +79,12 @@ class MessageChannelBuilder {
 			Buffer.of(0x54, 0x79, 0xCE, 0x31, 0xA0, 0x32, 0x48, 0x4D),
 			ServerMessageHandler.finalizedBlock
 		);
-		this.add('confirmedAdded', 'a', ServerMessageHandler.transaction);
-		this.add('unconfirmedAdded', 'u', ServerMessageHandler.transaction);
-		this.add('unconfirmedRemoved', 'r', ServerMessageHandler.transactionHash);
+		this.add('confirmedAdded', 'a', ServerMessageHandler.zmqMessageHandler);
+		this.add('unconfirmedAdded', 'u', ServerMessageHandler.zmqMessageHandler);
+		this.add('unconfirmedRemoved', 'r', ServerMessageHandler.zmqMessageHandler);
 		this.descriptors.status = {
 			filter: this.createAddressFilter('s'),
-			handler: ServerMessageHandler.transactionStatus
+			handler: ServerMessageHandler.zmqMessageHandler
 		};
 	}
 

--- a/rest/src/connection/serverMessageHandlers.js
+++ b/rest/src/connection/serverMessageHandlers.js
@@ -21,6 +21,7 @@
 
 const catapult = require('catapult-sdk');
 
+const { address } = catapult.model;
 const { uint64 } = catapult.utils;
 
 const parserFromData = binaryData => {
@@ -29,44 +30,104 @@ const parserFromData = binaryData => {
 	return parser;
 };
 
+const block = (codec, emitter, binaryBlock, hash, generationHash) => {
+	const blockObj = codec.deserialize(parserFromData(binaryBlock));
+	emitter.emit('block', { type: 'blockHeaderWithMetadata', payload: { block: blockObj, meta: { hash, generationHash } } });
+};
+
+const finalizedBlock = (emitter, binaryBlock) => {
+	const parser = parserFromData(binaryBlock);
+
+	const finalizationEpoch = parser.uint32();
+	const finalizationPoint = parser.uint32();
+	const height = parser.uint64();
+	const hash = parser.buffer(catapult.constants.sizes.hash256);
+	emitter.emit('finalizedBlock', {
+		type: 'finalizedBlock',
+		payload: {
+			finalizationEpoch, finalizationPoint, height, hash
+		}
+	});
+};
+
+const transaction = (codec, emitter, key, binaryTransaction, hash, merkleComponentHash, height) => {
+	const transactionObj = codec.deserialize(parserFromData(binaryTransaction));
+	const meta = { hash, merkleComponentHash, height: uint64.fromBytes(height) };
+	emitter.emit(key, { type: 'transactionWithMetadata', payload: { transaction: transactionObj, meta } });
+};
+
+const transactionHash = (emitter, key, hash) => {
+	emitter.emit(key, { type: 'transactionWithMetadata', payload: { meta: { hash } } });
+};
+
+const transactionStatus = (emitter, key, buffer) => {
+	const parser = parserFromData(buffer);
+
+	const hash = parser.buffer(catapult.constants.sizes.hash256);
+	const deadline = parser.uint64();
+	const code = parser.uint32();
+	emitter.emit(key, { type: 'transactionStatus', payload: { hash, code, deadline } });
+};
+
+const cosignature = (emitter, key, buffer) => {
+	const parser = parserFromData(buffer);
+	const version = parser.uint64();
+	const signerPublicKey = parser.buffer(catapult.constants.sizes.signerPublicKey);
+	const signature = parser.buffer(catapult.constants.sizes.signature);
+	const parentHash = parser.buffer(catapult.constants.sizes.hash256);
+	emitter.emit(key, {
+		type: 'aggregate.cosignature',
+		payload: {
+			version,
+			signerPublicKey,
+			signature,
+			parentHash
+		}
+	});
+};
+
+const getKeyByTopic = (codec, emitter, message) => {
+	const topic = message[0];
+	if (topic.equals(Buffer.of(0x49, 0x6A, 0xCA, 0x80, 0xE4, 0xD8, 0xF2, 0x9F))) {
+		block(codec, emitter, message[1], message[2], message[3]);
+	} else if (topic.equals(Buffer.of(0x54, 0x79, 0xCE, 0x31, 0xA0, 0x32, 0x48, 0x4D))) {
+		finalizedBlock(emitter, message[1]);
+	} else {
+		const maker = topic[0];
+		const paramByte = topic.subarray(1, topic.length);
+		const topicParam = 8 > paramByte ? undefined : address.addressToString(paramByte);
+		switch (maker) {
+		case 'a'.charCodeAt(0):
+			transaction(codec, emitter, `confirmedAdded/${topicParam}`, message[1], message[2], message[3], message[4]);
+			break;
+		case 'u'.charCodeAt(0):
+			transaction(codec, emitter, `unconfirmedAdded/${topicParam}`, message[1], message[2], message[3], message[4]);
+			break;
+		case 'r'.charCodeAt(0):
+			transactionHash(emitter, `unconfirmedRemoved/${topicParam}`, message[1]);
+			break;
+		case 's'.charCodeAt(0):
+			transactionStatus(emitter, `status/${topicParam}`, message[1]);
+			break;
+		case 'p'.charCodeAt(0):
+			transaction(codec, emitter, `partialAdded/${topicParam}`, message[1], message[2], message[3], message[4]);
+			break;
+		case 'q'.charCodeAt(0):
+			transactionHash(emitter, `partialRemoved/${topicParam}`, message[1]);
+			break;
+		case 'c'.charCodeAt(0):
+			cosignature(emitter, `cosignature/${topicParam}`, message[1]);
+			break;
+		default:
+			break;
+		}
+	}
+};
+
 const ServerMessageHandler = Object.freeze({
-	block: (codec, emit) => (topic, binaryBlock, hash, generationHash) => {
-		const block = codec.deserialize(parserFromData(binaryBlock));
-		emit({ type: 'blockHeaderWithMetadata', payload: { block, meta: { hash, generationHash } } });
-	},
-
-	finalizedBlock: (codec, emit) => (topic, binaryBlock) => {
-		const parser = parserFromData(binaryBlock);
-
-		const finalizationEpoch = parser.uint32();
-		const finalizationPoint = parser.uint32();
-		const height = parser.uint64();
-		const hash = parser.buffer(catapult.constants.sizes.hash256);
-		emit({
-			type: 'finalizedBlock',
-			payload: {
-				finalizationEpoch, finalizationPoint, height, hash
-			}
-		});
-	},
-
-	transaction: (codec, emit) => (topic, binaryTransaction, hash, merkleComponentHash, height) => {
-		const transaction = codec.deserialize(parserFromData(binaryTransaction));
-		const meta = { hash, merkleComponentHash, height: uint64.fromBytes(height) };
-		emit({ type: 'transactionWithMetadata', payload: { transaction, meta } });
-	},
-
-	transactionHash: (codec, emit) => (topic, hash) => {
-		emit({ type: 'transactionWithMetadata', payload: { meta: { hash } } });
-	},
-
-	transactionStatus: (codec, emit) => (topic, buffer) => {
-		const parser = parserFromData(buffer);
-
-		const hash = parser.buffer(catapult.constants.sizes.hash256);
-		const deadline = parser.uint64();
-		const code = parser.uint32();
-		emit({ type: 'transactionStatus', payload: { hash, code, deadline } });
+	zmqMessageHandler: (codec, emitter) => (...args) => {
+		if (args && args.length)
+			getKeyByTopic(codec, emitter, args);
 	}
 });
 

--- a/rest/src/connection/zmqService.js
+++ b/rest/src/connection/zmqService.js
@@ -18,7 +18,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+const { ServerMessageHandler } = require('./serverMessageHandlers');
 const zmqUtils = require('./zmqUtils');
 const zmq = require('zeromq');
 

--- a/rest/src/connection/zmqUtils.js
+++ b/rest/src/connection/zmqUtils.js
@@ -119,7 +119,7 @@ module.exports = {
 		const socketMatchingKey = key => {
 			const [topicCategory, topicParam] = key.replace('.close', '').split('/');
 			return !topicParam ? topicCategory : topicParam;
-		}
+		};
 		const connectedSocket = {};
 		const multisocketEmitter = {
 			on: (key, callback) => {
@@ -131,10 +131,9 @@ module.exports = {
 					zsocket.on('zsocket_close', () => {
 						// firing of close indicates socket is fully closed, so prevent it from being closed again
 						// by bypassing close in removeAllListeners
-						Object.keys(zsockets).forEach((k) => {
-							if (k.includes(socketMatchingKey(key))) {
+						Object.keys(zsockets).forEach(k => {
+							if (k.includes(socketMatchingKey(key)))
 								delete zsockets[k];
-							}
 						});
 						emitter.emit(`${key}.close`);
 						multisocketEmitter.removeAllListeners(key);
@@ -142,7 +141,6 @@ module.exports = {
 					zsockets[key] = zsocket;
 				}
 				emitter.on(key, callback);
-				
 			},
 
 			removeAllListeners: key => {
@@ -156,12 +154,10 @@ module.exports = {
 
 				const zsocket = zsockets[key];
 				delete zsockets[key];
-				if (!Object.keys(zsockets).find((k) => k.indexOf(socketMatchingKey(key)) > -1)) {
+				if (!Object.keys(zsockets).find(k => -1 < k.indexOf(socketMatchingKey(key)))) {
 					zsocket.close();
 					delete connectedSocket[socketMatchingKey(key)];
 				}
-
-				console.log(`zmq Subscription count: ${Object.keys(zsockets).length}, Socket opened ${Object.keys(connectedSocket).length}`);
 			},
 
 			listenerCount: key => emitter.listenerCount(key),

--- a/rest/src/connection/zmqUtils.js
+++ b/rest/src/connection/zmqUtils.js
@@ -116,25 +116,33 @@ module.exports = {
 		const zsockets = {};
 		const isSubEvent = key => -1 !== key.indexOf('.');
 		const isValidSubEvent = key => key.endsWith('.close');
+		const socketMatchingKey = key => {
+			const [topicCategory, topicParam] = key.replace('.close', '').split('/');
+			return !topicParam ? topicCategory : topicParam;
+		}
+		const connectedSocket = {};
 		const multisocketEmitter = {
 			on: (key, callback) => {
 				if (isSubEvent(key)) {
 					if (!isValidSubEvent(key))
 						throw Error(`${key} indicates an unsupported subevent`);
 				} else if (!(key in zsockets)) {
-					const zsocket = zsocketFactory(key, emitter, multisocketEmitter.zsocketCount());
+					const zsocket = zsocketFactory(key, emitter, zsockets, connectedSocket);
 					zsocket.on('zsocket_close', () => {
 						// firing of close indicates socket is fully closed, so prevent it from being closed again
 						// by bypassing close in removeAllListeners
-						delete zsockets[key];
-
+						Object.keys(zsockets).forEach((k) => {
+							if (k.includes(socketMatchingKey(key))) {
+								delete zsockets[k];
+							}
+						});
 						emitter.emit(`${key}.close`);
 						multisocketEmitter.removeAllListeners(key);
 					});
 					zsockets[key] = zsocket;
 				}
-
 				emitter.on(key, callback);
+				
 			},
 
 			removeAllListeners: key => {
@@ -148,7 +156,12 @@ module.exports = {
 
 				const zsocket = zsockets[key];
 				delete zsockets[key];
-				zsocket.close();
+				if (!Object.keys(zsockets).find((k) => k.indexOf(socketMatchingKey(key)) > -1)) {
+					zsocket.close();
+					delete connectedSocket[socketMatchingKey(key)];
+				}
+
+				console.log(`zmq Subscription count: ${Object.keys(zsockets).length}, Socket opened ${Object.keys(connectedSocket).length}`);
 			},
 
 			listenerCount: key => emitter.listenerCount(key),

--- a/rest/src/plugins/aggregate/aggregate.js
+++ b/rest/src/plugins/aggregate/aggregate.js
@@ -38,26 +38,9 @@ module.exports = {
 	},
 
 	registerMessageChannels: builder => {
-		builder.add('partialAdded', 'p', ServerMessageHandler.transaction);
-		builder.add('partialRemoved', 'q', ServerMessageHandler.transactionHash);
-		builder.add('cosignature', 'c', (codec, emit) => (topic, buffer) => {
-			const parser = new BinaryParser();
-			parser.push(buffer);
-
-			const version = parser.uint64();
-			const signerPublicKey = parser.buffer(catapult.constants.sizes.signerPublicKey);
-			const signature = parser.buffer(catapult.constants.sizes.signature);
-			const parentHash = parser.buffer(catapult.constants.sizes.hash256);
-			emit({
-				type: 'aggregate.cosignature',
-				payload: {
-					version,
-					signerPublicKey,
-					signature,
-					parentHash
-				}
-			});
-		});
+		builder.add('partialAdded', 'p', ServerMessageHandler.zmqMessageHandler);
+		builder.add('partialRemoved', 'q', ServerMessageHandler.zmqMessageHandler);
+		builder.add('cosignature', 'c', ServerMessageHandler.zmqMessageHandler);
 	},
 
 	registerRoutes: (...args) => {

--- a/rest/src/plugins/aggregate/aggregate.js
+++ b/rest/src/plugins/aggregate/aggregate.js
@@ -22,9 +22,6 @@
 /** @module plugins/aggregate */
 const aggregateRoutes = require('./aggregateRoutes');
 const { ServerMessageHandler } = require('../../connection/serverMessageHandlers');
-const catapult = require('catapult-sdk');
-
-const { BinaryParser } = catapult.parser;
 
 /**
  * Creates an aggregate plugin.

--- a/rest/test/connection/MessageChannelBuilder_spec.js
+++ b/rest/test/connection/MessageChannelBuilder_spec.js
@@ -133,7 +133,7 @@ describe('message channel builder', () => {
 			describe('handler', () => {
 				it('is set to block type', () => {
 					const messageChannelBuilder = new MessageChannelBuilder({}, networkIdentifier);
-					expect(messageChannelBuilder.descriptors.block.handler).to.equal(ServerMessageHandler.block);
+					expect(messageChannelBuilder.descriptors.block.handler).to.equal(ServerMessageHandler.zmqMessageHandler);
 				});
 			});
 		});
@@ -143,7 +143,7 @@ describe('message channel builder', () => {
 			describe('handler', () => {
 				it('is set to transaction type', () => {
 					const messageChannelBuilder = new MessageChannelBuilder({}, networkIdentifier);
-					expect(messageChannelBuilder.descriptors.confirmedAdded.handler).to.equal(ServerMessageHandler.transaction);
+					expect(messageChannelBuilder.descriptors.confirmedAdded.handler).to.equal(ServerMessageHandler.zmqMessageHandler);
 				});
 			});
 		});
@@ -153,7 +153,7 @@ describe('message channel builder', () => {
 			describe('handler', () => {
 				it('is set to transaction type', () => {
 					const messageChannelBuilder = new MessageChannelBuilder({}, networkIdentifier);
-					expect(messageChannelBuilder.descriptors.unconfirmedAdded.handler).to.equal(ServerMessageHandler.transaction);
+					expect(messageChannelBuilder.descriptors.unconfirmedAdded.handler).to.equal(ServerMessageHandler.zmqMessageHandler);
 				});
 			});
 		});
@@ -163,7 +163,7 @@ describe('message channel builder', () => {
 			describe('handler', () => {
 				it('is set to transaction type', () => {
 					const messageChannelBuilder = new MessageChannelBuilder({}, networkIdentifier);
-					expect(messageChannelBuilder.descriptors.unconfirmedRemoved.handler).to.equal(ServerMessageHandler.transactionHash);
+					expect(messageChannelBuilder.descriptors.unconfirmedRemoved.handler).to.equal(ServerMessageHandler.zmqMessageHandler);
 				});
 			});
 		});
@@ -173,7 +173,7 @@ describe('message channel builder', () => {
 			describe('handler', () => {
 				it('is set to transaction type', () => {
 					const messageChannelBuilder = new MessageChannelBuilder({}, networkIdentifier);
-					expect(messageChannelBuilder.descriptors.status.handler).to.equal(ServerMessageHandler.transactionStatus);
+					expect(messageChannelBuilder.descriptors.status.handler).to.equal(ServerMessageHandler.zmqMessageHandler);
 				});
 			});
 		});
@@ -190,7 +190,7 @@ describe('message channel builder', () => {
 				it('is set to transaction type', () => {
 					const messageChannelBuilder = new MessageChannelBuilder({}, networkIdentifier);
 					createChannelInfo(messageChannelBuilder);
-					expect(messageChannelBuilder.descriptors.foo.handler).to.equal(ServerMessageHandler.transaction);
+					expect(messageChannelBuilder.descriptors.foo.handler).to.equal(ServerMessageHandler.zmqMessageHandler);
 				});
 			});
 		});
@@ -205,7 +205,7 @@ describe('message channel builder', () => {
 				it('is set to transaction hash type', () => {
 					const messageChannelBuilder = new MessageChannelBuilder({}, networkIdentifier);
 					createChannelInfo(messageChannelBuilder);
-					expect(messageChannelBuilder.descriptors.foo.handler).to.equal(ServerMessageHandler.transactionHash);
+					expect(messageChannelBuilder.descriptors.foo.handler).to.equal(ServerMessageHandler.zmqMessageHandler);
 				});
 			});
 		});

--- a/rest/test/connection/MessageChannelBuilder_spec.js
+++ b/rest/test/connection/MessageChannelBuilder_spec.js
@@ -141,7 +141,7 @@ describe('message channel builder', () => {
 		describe('confirmedAdded', () => {
 			describe('filter', () => { addAddressFilterTests(0x61, builder => builder.build().confirmedAdded.filter); });
 			describe('handler', () => {
-				it('is set to transaction type', () => {
+				it('is set to zmqMessageHandler type', () => {
 					const messageChannelBuilder = new MessageChannelBuilder({}, networkIdentifier);
 					expect(messageChannelBuilder.descriptors.confirmedAdded.handler).to.equal(ServerMessageHandler.zmqMessageHandler);
 				});
@@ -182,7 +182,7 @@ describe('message channel builder', () => {
 	describe('custom channels', () => {
 		describe('with transaction handler', () => {
 			const createChannelInfo = builder => {
-				builder.add('foo', 'z', ServerMessageHandler.transaction);
+				builder.add('foo', 'z', ServerMessageHandler.zmqMessageHandler);
 				return builder.build().foo;
 			};
 			describe('filter', () => { addAddressFilterTests(0x7A, builder => createChannelInfo(builder).filter); });
@@ -197,7 +197,7 @@ describe('message channel builder', () => {
 
 		describe('with transaction hash handler', () => {
 			const createChannelInfo = builder => {
-				builder.add('foo', 'z', ServerMessageHandler.transactionHash);
+				builder.add('foo', 'z', ServerMessageHandler.zmqMessageHandler);
 				return builder.build().foo;
 			};
 			describe('filter', () => { addAddressFilterTests(0x7A, builder => createChannelInfo(builder).filter); });
@@ -252,7 +252,8 @@ describe('message channel builder', () => {
 			const builder = new MessageChannelBuilder({}, networkIdentifier);
 
 			// Assert:
-			expect(() => builder.add('foo', 'zz', ServerMessageHandler.transaction)).to.throw('channel marker must be single character');
+			expect(() => builder.add('foo', 'zz',
+				ServerMessageHandler.zmqMessageHandler)).to.throw('channel marker must be single character');
 		});
 
 		it('cannot override default channel', () => {
@@ -260,19 +261,24 @@ describe('message channel builder', () => {
 			const builder = new MessageChannelBuilder({}, networkIdentifier);
 
 			// Assert:
-			expect(() => builder.add('status', 'z', ServerMessageHandler.transaction)).to.throw('channel has already been registered');
-			expect(() => builder.add('foo', 'u', ServerMessageHandler.transaction)).to.throw('channel marker has already been registered');
+			expect(() => builder.add('status', 'z',
+				ServerMessageHandler.zmqMessageHandler)).to.throw('channel has already been registered');
+			expect(() => builder.add('foo', 'u',
+				ServerMessageHandler.zmqMessageHandler)).to.throw('channel marker has already been registered');
 		});
 
 		it('cannot be registered multiple times', () => {
 			// Arrange:
 			const builder = new MessageChannelBuilder({}, networkIdentifier);
-			builder.add('foo', 'z', ServerMessageHandler.transaction);
+			builder.add('foo', 'z', ServerMessageHandler.zmqMessageHandler);
 
 			// Assert:
-			expect(() => builder.add('foo', 'z', ServerMessageHandler.transaction)).to.throw('channel has already been registered');
-			expect(() => builder.add('foo', 'y', ServerMessageHandler.transaction)).to.throw('channel has already been registered');
-			expect(() => builder.add('bar', 'z', ServerMessageHandler.transaction)).to.throw('channel marker has already been registered');
+			expect(() => builder.add('foo', 'z',
+				ServerMessageHandler.zmqMessageHandler)).to.throw('channel has already been registered');
+			expect(() => builder.add('foo', 'y',
+				ServerMessageHandler.zmqMessageHandler)).to.throw('channel has already been registered');
+			expect(() => builder.add('bar', 'z',
+				ServerMessageHandler.zmqMessageHandler)).to.throw('channel marker has already been registered');
 		});
 	});
 });

--- a/rest/test/connection/serverMessageHandlers_spec.js
+++ b/rest/test/connection/serverMessageHandlers_spec.js
@@ -43,7 +43,7 @@ describe('server message handlers', () => {
 		const blockBuffer = Buffer.of(0xAB, 0xCD, 0xEF);
 
 		// Act:
-		ServerMessageHandler.block(codec, eventData => emitted.push(eventData))(12, blockBuffer, 56, 78, 99, 88);
+		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(12, blockBuffer, 56, 78, 99, 88);
 
 		// Assert:
 		// - 12 is a "topic" so it's not forwarded
@@ -70,7 +70,7 @@ describe('server message handlers', () => {
 		]);
 
 		// Act:
-		ServerMessageHandler.finalizedBlock(codec, eventData => emitted.push(eventData))(12, finalizedBlockBuffer, 99, 88);
+		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(12, finalizedBlockBuffer, 99, 88);
 
 		// Assert:
 		// - 12 is a "topic" so it's not forwarded
@@ -97,7 +97,7 @@ describe('server message handlers', () => {
 
 		// Act:
 		const height = Buffer.of(66, 0, 0, 0, 0, 0, 0, 0);
-		ServerMessageHandler.transaction(codec, eventData => emitted.push(eventData))(22, transactionBuffer, 44, 55, height, 77, 88, 99);
+		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(22, transactionBuffer, 44, 55, height, 77, 88, 99);
 
 		// Assert:
 		// - 22 is a "topic" so it's not forwarded
@@ -126,7 +126,7 @@ describe('server message handlers', () => {
 		const codec = createMockCodec(35);
 
 		// Act:
-		ServerMessageHandler.transactionHash(codec, eventData => emitted.push(eventData))(22, 44, 77, 88, 99);
+		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(22, 44, 77, 88, 99);
 
 		// Assert:
 		// - 22 is a "topic" so it's not forwarded
@@ -148,7 +148,7 @@ describe('server message handlers', () => {
 		]);
 
 		// Act:
-		ServerMessageHandler.transactionStatus(codec, eventData => emitted.push(eventData))(22, buffer, 99);
+		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(22, buffer, 99);
 
 		// Assert:
 		// - 22 is a "topic" so it's not forwarded

--- a/rest/test/connection/serverMessageHandlers_spec.js
+++ b/rest/test/connection/serverMessageHandlers_spec.js
@@ -21,9 +21,14 @@
 
 const { ServerMessageHandler } = require('../../src/connection/serverMessageHandlers');
 const test = require('../testUtils');
+const catapult = require('catapult-sdk');
 const { expect } = require('chai');
+const { EventEmitter } = require('ws');
+
+const { address } = catapult.model;
 
 describe('server message handlers', () => {
+	const addressBuffer = Buffer.from(address.stringToAddress('TAHNZXQBC57AA7KJTMGS3PJPZBXN7DV5JHJU42A'));
 	const createMockCodec = value => {
 		const mock = {
 			// only some message handlers require codec, objects passed to codec.deserialize() are collected in following array
@@ -41,9 +46,12 @@ describe('server message handlers', () => {
 		const emitted = [];
 		const codec = createMockCodec(34);
 		const blockBuffer = Buffer.of(0xAB, 0xCD, 0xEF);
-
+		const emitter = new EventEmitter();
+		emitter.on('block', data => emitted.push(data));
 		// Act:
-		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(12, blockBuffer, 56, 78, 99, 88);
+		ServerMessageHandler.zmqMessageHandler(codec, emitter)(
+			Buffer.of(0x49, 0x6A, 0xCA, 0x80, 0xE4, 0xD8, 0xF2, 0x9F), blockBuffer, 56, 78, 99, 88
+		);
 
 		// Assert:
 		// - 12 is a "topic" so it's not forwarded
@@ -68,9 +76,13 @@ describe('server message handlers', () => {
 			Buffer.of(66, 0, 0, 0, 0, 0, 0, 0), // height
 			Buffer.alloc(test.constants.sizes.hash256, 41) // hash
 		]);
+		const emitter = new EventEmitter();
+		emitter.on('finalizedBlock', data => emitted.push(data));
 
 		// Act:
-		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(12, finalizedBlockBuffer, 99, 88);
+		ServerMessageHandler.zmqMessageHandler(codec, emitter)(
+			Buffer.of(0x54, 0x79, 0xCE, 0x31, 0xA0, 0x32, 0x48, 0x4D), finalizedBlockBuffer, 99, 88
+		);
 
 		// Assert:
 		// - 12 is a "topic" so it's not forwarded
@@ -94,10 +106,14 @@ describe('server message handlers', () => {
 		const emitted = [];
 		const codec = createMockCodec(33);
 		const transactionBuffer = Buffer.of(0xEF, 0xCD, 0xAB);
+		const emitter = new EventEmitter();
+		emitter.on('confirmedAdded/TAHNZXQBC57AA7KJTMGS3PJPZBXN7DV5JHJU42A', data => emitted.push(data));
 
 		// Act:
 		const height = Buffer.of(66, 0, 0, 0, 0, 0, 0, 0);
-		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(22, transactionBuffer, 44, 55, height, 77, 88, 99);
+		ServerMessageHandler.zmqMessageHandler(codec, emitter)(Buffer.concat(
+			[Buffer.of('a'.charCodeAt(0)), addressBuffer]
+		), transactionBuffer, 44, 55, height, 77, 88, 99);
 
 		// Assert:
 		// - 22 is a "topic" so it's not forwarded
@@ -124,9 +140,13 @@ describe('server message handlers', () => {
 		// Arrange:
 		const emitted = [];
 		const codec = createMockCodec(35);
+		const emitter = new EventEmitter();
+		emitter.on('unconfirmedRemoved/TAHNZXQBC57AA7KJTMGS3PJPZBXN7DV5JHJU42A', data => emitted.push(data));
 
 		// Act:
-		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(22, 44, 77, 88, 99);
+		ServerMessageHandler.zmqMessageHandler(codec, emitter)(
+			Buffer.concat([Buffer.of('r'.charCodeAt(0)), addressBuffer]), 44, 77, 88, 99
+		);
 
 		// Assert:
 		// - 22 is a "topic" so it's not forwarded
@@ -147,8 +167,13 @@ describe('server message handlers', () => {
 			Buffer.of(55, 0, 0, 0) // status
 		]);
 
+		const emitter = new EventEmitter();
+		emitter.on('status/TAHNZXQBC57AA7KJTMGS3PJPZBXN7DV5JHJU42A', data => emitted.push(data));
+
 		// Act:
-		ServerMessageHandler.zmqMessageHandler(codec, eventData => emitted.push(eventData))(22, buffer, 99);
+		ServerMessageHandler.zmqMessageHandler(codec, emitter)(
+			Buffer.concat([Buffer.of('s'.charCodeAt(0)), addressBuffer]), buffer, 99
+		);
 
 		// Assert:
 		// - 22 is a "topic" so it's not forwarded

--- a/rest/test/plugins/aggregate/aggregate_spec.js
+++ b/rest/test/plugins/aggregate/aggregate_spec.js
@@ -63,7 +63,7 @@ describe('aggregate plugin', () => {
 			const descriptor = registerAndExtractChannelDescriptor('partialAdded');
 
 			// Assert:
-			expect(descriptor).to.deep.equal({ name: 'partialAdded', markerChar: 'p', handler: ServerMessageHandler.transaction });
+			expect(descriptor).to.deep.equal({ name: 'partialAdded', markerChar: 'p', handler: ServerMessageHandler.zmqMessageHandler });
 		});
 
 		it('registers partialRemoved', () => {
@@ -71,7 +71,7 @@ describe('aggregate plugin', () => {
 			const descriptor = registerAndExtractChannelDescriptor('partialRemoved');
 
 			// Assert:
-			expect(descriptor).to.deep.equal({ name: 'partialRemoved', markerChar: 'q', handler: ServerMessageHandler.transactionHash });
+			expect(descriptor).to.deep.equal({ name: 'partialRemoved', markerChar: 'q', handler: ServerMessageHandler.zmqMessageHandler });
 		});
 
 		it('registers cosignature', () => {

--- a/rest/test/plugins/aggregate/aggregate_spec.js
+++ b/rest/test/plugins/aggregate/aggregate_spec.js
@@ -23,10 +23,25 @@ const { ServerMessageHandler } = require('../../../src/connection/serverMessageH
 const aggregate = require('../../../src/plugins/aggregate/aggregate');
 const { test } = require('../../routes/utils/routeTestUtils');
 const pluginTest = require('../utils/pluginTestUtils');
+const catapult = require('catapult-sdk');
 const { expect } = require('chai');
+const { EventEmitter } = require('ws');
+
+const { address } = catapult.model;
 
 describe('aggregate plugin', () => {
 	pluginTest.assertThat.pluginDoesNotCreateDb(aggregate);
+	const createMockCodec = value => {
+		const mock = {
+			// only some message handlers require codec, objects passed to codec.deserialize() are collected in following array
+			collected: [],
+			deserialize: (parser, options) => {
+				mock.collected.push({ parser, options });
+				return value;
+			}
+		};
+		return mock;
+	};
 
 	describe('register transaction states', () => {
 		it('registers partial state', () => {
@@ -86,8 +101,7 @@ describe('aggregate plugin', () => {
 		it('registers cosignature with handler that forwards to emit callback', () => {
 			// Arrange:
 			const emitted = [];
-			const { handler } = registerAndExtractChannelDescriptor('cosignature');
-
+			const codec = createMockCodec(33);
 			// Act:
 			const buffer = Buffer.concat([
 				Buffer.of(0x34, 0x54, 0x55, 0xFF, 0xFA, 0x0E, 0xCC, 0xB7),
@@ -95,7 +109,14 @@ describe('aggregate plugin', () => {
 				Buffer.alloc(test.constants.sizes.signature, 44),
 				Buffer.alloc(test.constants.sizes.hash256, 55)
 			]);
-			handler({}, eventData => emitted.push(eventData))(22, buffer, 99);
+			const addressBuffer = Buffer.from(address.stringToAddress('TAHNZXQBC57AA7KJTMGS3PJPZBXN7DV5JHJU42A'));
+			const emitter = new EventEmitter();
+			emitter.on('cosignature/TAHNZXQBC57AA7KJTMGS3PJPZBXN7DV5JHJU42A', data => emitted.push(data));
+
+			// Act:
+			ServerMessageHandler.zmqMessageHandler(codec, emitter)(
+				Buffer.concat([Buffer.of('c'.charCodeAt(0)), addressBuffer]), buffer, 99
+			);
 
 			// Assert:
 			// - 22 is a "topic" so it's not forwarded


### PR DESCRIPTION
- Combined server message handler into one.
- Combined message channels builders
- Grouped zmq sockets by topic parameters(address if any). Server will check if existing socket connections with the same topic param (address) or topic name (block) and reuse the existing socket.
- Existing zmqSubimission and socket emitter 1:1 relationship unchanged.