### PR TITLE
CMC specific endpoints

### DIFF
--- a/rest/src/plugins/mosaic/mosaicRoutes.js
+++ b/rest/src/plugins/mosaic/mosaicRoutes.js
@@ -63,7 +63,7 @@ module.exports = {
 
 		// CMC specific endpoint
 		server.get('/network/currency/circulating', (req, res, next) => {
-			const networkMosaicId = [ 245791924, 1425519112 ]//[ 2718049272, 1810731327 ] //6BED913FA20223F8;
+			const networkMosaicId = [ 2718049272, 1810731327 ] //6BED913FA20223F8;
 			return db.mosaicsByIds([networkMosaicId]).then(response => {
 				const supply = response[0].mosaic.supply.toString().slice(0, -6);
 				res.setHeader('content-type', 'text/plain');

--- a/rest/src/plugins/mosaic/mosaicRoutes.js
+++ b/rest/src/plugins/mosaic/mosaicRoutes.js
@@ -60,5 +60,16 @@ module.exports = {
 				next();
 			});
 		});
+
+		// CMC specific endpoint
+		server.get('/network/currency/circulating', (req, res, next) => {
+			const networkMosaicId = [ 245791924, 1425519112 ]//[ 2718049272, 1810731327 ] //6BED913FA20223F8;
+			return db.mosaicsByIds([networkMosaicId]).then(response => {
+				const supply = response[0].mosaic.supply.toString().slice(0, -6);
+				res.setHeader('content-type', 'text/plain');
+				res.send(supply);
+				next();
+			});
+		});
 	}
 };

--- a/rest/src/plugins/mosaic/mosaicRoutes.js
+++ b/rest/src/plugins/mosaic/mosaicRoutes.js
@@ -65,7 +65,8 @@ module.exports = {
 		server.get('/network/currency/circulating', (req, res, next) => {
 			const networkMosaicId = [2718049272, 1810731327]; // 6BED913FA20223F8;
 			return db.mosaicsByIds([networkMosaicId]).then(response => {
-				const supply = response[0].mosaic.supply.toString().slice(0, -6);
+				const s = response[0].mosaic.supply.toString();
+				const supply = s.substring(0, s.length - 6) + "."+ s.substring(s.length - 6, s.length);
 				res.setHeader('content-type', 'text/plain');
 				res.send(supply);
 				next();

--- a/rest/src/plugins/mosaic/mosaicRoutes.js
+++ b/rest/src/plugins/mosaic/mosaicRoutes.js
@@ -62,9 +62,10 @@ module.exports = {
 		});
 
 		// CMC specific endpoint
-		server.get('/network/currency/circulating', (req, res, next) => {
-			const networkMosaicId = [2718049272, 1810731327]; // 6BED913FA20223F8;
-			return db.mosaicsByIds([networkMosaicId]).then(response => {
+		server.get('/network/currency/circulating/:mosaicId', (req, res, next) => {
+			const mosaicId = routeUtils.parseArgument(req.params, 'mosaicId',
+				'uint64hex');
+			return db.mosaicsByIds([mosaicId]).then(response => {
 				const s = response[0].mosaic.supply.toString();
 				const supply = s.substring(0, s.length - 6) + "."+ s.substring(s.length - 6, s.length);
 				res.setHeader('content-type', 'text/plain');

--- a/rest/src/plugins/mosaic/mosaicRoutes.js
+++ b/rest/src/plugins/mosaic/mosaicRoutes.js
@@ -63,7 +63,7 @@ module.exports = {
 
 		// CMC specific endpoint
 		server.get('/network/currency/circulating', (req, res, next) => {
-			const networkMosaicId = [ 2718049272, 1810731327 ] //6BED913FA20223F8;
+			const networkMosaicId = [2718049272, 1810731327]; // 6BED913FA20223F8;
 			return db.mosaicsByIds([networkMosaicId]).then(response => {
 				const supply = response[0].mosaic.supply.toString().slice(0, -6);
 				res.setHeader('content-type', 'text/plain');

--- a/rest/src/routes/networkRoutes.js
+++ b/rest/src/routes/networkRoutes.js
@@ -129,5 +129,18 @@ module.exports = {
 				next();
 			});
 		});
+
+		// CMC specific, only return the plain value of the max mosaic supply
+		server.get('/network/currency/total', (req, res, next) => readAndParseNetworkPropertiesFile()
+		.then(propertiesObject => {
+			const maxSupply = propertiesObject.chain.maxMosaicAtomicUnits.replace(/'/g, '').slice(0, -6);
+			res.setHeader('content-type', 'text/plain');
+			res.send(maxSupply);
+			next();
+		}).catch((e) => {
+			console.log(e)
+			res.send(errors.createInvalidArgumentError('there was an error reading the network properties file'));
+			next();
+		}));
 	}
 };

--- a/rest/src/routes/networkRoutes.js
+++ b/rest/src/routes/networkRoutes.js
@@ -137,7 +137,7 @@ module.exports = {
 				res.setHeader('content-type', 'text/plain');
 				res.send(maxSupply);
 				next();
-			}).catch(e => {
+			}).catch(() => {
 				res.send(errors.createInvalidArgumentError('there was an error reading the network properties file'));
 				next();
 			}));

--- a/rest/src/routes/networkRoutes.js
+++ b/rest/src/routes/networkRoutes.js
@@ -132,15 +132,14 @@ module.exports = {
 
 		// CMC specific, only return the plain value of the max mosaic supply
 		server.get('/network/currency/total', (req, res, next) => readAndParseNetworkPropertiesFile()
-		.then(propertiesObject => {
-			const maxSupply = propertiesObject.chain.maxMosaicAtomicUnits.replace(/'/g, '').slice(0, -6);
-			res.setHeader('content-type', 'text/plain');
-			res.send(maxSupply);
-			next();
-		}).catch((e) => {
-			console.log(e)
-			res.send(errors.createInvalidArgumentError('there was an error reading the network properties file'));
-			next();
-		}));
+			.then(propertiesObject => {
+				const maxSupply = propertiesObject.chain.maxMosaicAtomicUnits.replace(/'/g, '').slice(0, -6);
+				res.setHeader('content-type', 'text/plain');
+				res.send(maxSupply);
+				next();
+			}).catch(e => {
+				res.send(errors.createInvalidArgumentError('there was an error reading the network properties file'));
+				next();
+			}));
 	}
 };

--- a/rest/test/plugins/mosaic/mosaic_spec.js
+++ b/rest/test/plugins/mosaic/mosaic_spec.js
@@ -43,7 +43,7 @@ describe('mosaic plugin', () => {
 				'/mosaics',
 				'/mosaics/:mosaicId',
 				'/mosaics/:mosaicId/merkle',
-				'/network/currency/circulating'
+				'/network/currency/circulating/:mosaicId'
 			]);
 		});
 

--- a/rest/test/plugins/mosaic/mosaic_spec.js
+++ b/rest/test/plugins/mosaic/mosaic_spec.js
@@ -43,7 +43,7 @@ describe('mosaic plugin', () => {
 				'/mosaics',
 				'/mosaics/:mosaicId',
 				'/mosaics/:mosaicId/merkle',
-				'/network/currency/circulating/:mosaicId'
+				'/network/currency/circulating'
 			]);
 		});
 

--- a/rest/test/plugins/mosaic/mosaic_spec.js
+++ b/rest/test/plugins/mosaic/mosaic_spec.js
@@ -42,7 +42,8 @@ describe('mosaic plugin', () => {
 			test.assert.assertRoutes(routes, [
 				'/mosaics',
 				'/mosaics/:mosaicId',
-				'/mosaics/:mosaicId/merkle'
+				'/mosaics/:mosaicId/merkle',
+				'/network/currency/circulating'
 			]);
 		});
 

--- a/rest/test/routes/allRoutes_spec.js
+++ b/rest/test/routes/allRoutes_spec.js
@@ -69,7 +69,9 @@ describe('all routes', () => {
 
 			'/transactions/:group/:transactionId',
 			'/transactions/:group',
-			'/transactionStatus/:hash'
+			'/transactionStatus/:hash',
+
+			'/network/currency/total'
 		]);
 	});
 


### PR DESCRIPTION
Added 2 new endpoints to return plain network currency supplies
- `/network/currency/circulating`
-  `/network/currency/total`

both return plain/text type