### PR TITLE
fix: removed decoded address

### DIFF
--- a/rest/src/db/dbUtils.js
+++ b/rest/src/db/dbUtils.js
@@ -82,12 +82,11 @@ const dbUtils = {
 	},
 
 	/**
-     * Formats binary to a base32 address or hex address
+     * Formats binary to a base32 address
      * @param {MongoDb.Binary} binary Address|NamespaceId from MongoDb.
-     * @param {boolean} formatAddressUsingBase32 if base32 format should be used when formatting an address. Hex otherwise.
-     * @returns {string} the address in base32 format or hex format depending on formatAddressUsingBase32
+     * @returns {string} the address in base32 format
      */
-	bufferToUnresolvedAddress: (binary, formatAddressUsingBase32) => {
+	bufferToUnresolvedAddress: (binary) => {
 		if (!binary)
 			return undefined;
 
@@ -102,7 +101,8 @@ const dbUtils = {
 				`Cannot convert binary address, unknown ${binary.constructor.name} type`
 			);
 		};
-		return formatAddressUsingBase32 ? address.addressToString(getBuffer()) : catapult.utils.convert.uint8ToHex(getBuffer());
+
+		return address.addressToString(getBuffer());
 	},
 
 	/**

--- a/rest/src/db/dbUtils.js
+++ b/rest/src/db/dbUtils.js
@@ -86,7 +86,7 @@ const dbUtils = {
      * @param {MongoDb.Binary} binary Address|NamespaceId from MongoDb.
      * @returns {string} the address in base32 format
      */
-	bufferToUnresolvedAddress: (binary) => {
+	bufferToUnresolvedAddress: binary => {
 		if (!binary)
 			return undefined;
 

--- a/rest/test/db/dbFormattingRules_spec.js
+++ b/rest/test/db/dbFormattingRules_spec.js
@@ -240,14 +240,14 @@ describe('db formatting rules', () => {
 		});
 	});
 
-	it('can format encodedAddress type using hex', () => {
+	it('can format encodedAddress type', () => {
 		// Arrange
 		const object = test.factory.createBinary(Buffer.from('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56', 'hex'));
 
 		// Act:
-		const result = formattingRules[ModelType.encodedAddress](object, false);
+		const result = formattingRules[ModelType.encodedAddress](object);
 
 		// Assert:
-		expect(result).to.equal('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56');
+		expect(result).to.equal('TDQNCOHK6KWDILABL7YLMMPMGYRORL72AS74YVQ');
 	});
 });

--- a/rest/test/db/dbUtils_spec.js
+++ b/rest/test/db/dbUtils_spec.js
@@ -174,21 +174,10 @@ describe('db utils', () => {
 			const object = Buffer.from('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56', 'hex');
 
 			// Act:
-			const result = dbUtils.bufferToUnresolvedAddress(object, true);
-
-			// Assert:
-			expect(result).to.equal('TDQNCOHK6KWDILABL7YLMMPMGYRORL72AS74YVQ');
-		});
-
-		it('can convert from Buffer to decoded address', () => {
-			// Arrange
-			const object = Buffer.from('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56', 'hex');
-
-			// Act:
 			const result = dbUtils.bufferToUnresolvedAddress(object);
 
 			// Assert:
-			expect(result).to.equal('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56');
+			expect(result).to.equal('TDQNCOHK6KWDILABL7YLMMPMGYRORL72AS74YVQ');
 		});
 
 		it('can convert from undefined to undefined address', () => {

--- a/rest/test/server/messageFormattingRules_spec.js
+++ b/rest/test/server/messageFormattingRules_spec.js
@@ -153,7 +153,7 @@ describe('message formatting rules', () => {
 		expect(result).to.deep.equal(true);
 	});
 
-	it('can format decodedAddress type', () => {
+	it('can format encodedAddress type', () => {
 		// Arrange:
 		const object = test.factory.createBinary(Buffer.from('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56', 'hex'));
 
@@ -161,6 +161,6 @@ describe('message formatting rules', () => {
 		const result = formattingRules[ModelType.encodedAddress](object);
 
 		// Assert:
-		expect(result).to.deep.equal('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56');
+		expect(result).to.deep.equal('TDQNCOHK6KWDILABL7YLMMPMGYRORL72AS74YVQ');
 	});
 });


### PR DESCRIPTION
### Current behavior 
- All the addresses in the REST response are in decoded format. 
- Example `98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56`

### What was the issue?
- `Decoded` address format is not user-friendly. We have feedback from the community and discussion, change the address to encoded format.
- Example `TDQNCOHK6KWDILABL7YLMMPMGYRORL72AS74YVQ`

### What's the fix?
- Convert addresses from decoded to encoded (base32) format.
- updated unit test